### PR TITLE
Correct use of tooltip events

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/drawable/GuiDraw.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/GuiDraw.java
@@ -18,7 +18,6 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import org.jetbrains.annotations.Nullable;
 import org.lwjgl.opengl.GL11;
 
 import java.util.List;

--- a/src/main/java/com/cleanroommc/modularui/drawable/GuiDraw.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/GuiDraw.java
@@ -18,6 +18,7 @@ import net.minecraftforge.fluids.Fluid;
 import net.minecraftforge.fluids.FluidStack;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
+import org.jetbrains.annotations.Nullable;
 import org.lwjgl.opengl.GL11;
 
 import java.util.List;
@@ -559,12 +560,12 @@ public class GuiDraw {
         GlStateManager.enableBlend();
     }
 
-    public static void drawTooltipBackground(List<String> lines, int x, int y, int textWidth, int height) {
+    public static void drawTooltipBackground(ItemStack stack, List<String> lines, int x, int y, int textWidth, int height) {
         // TODO theme color
         int backgroundColor = 0xF0100010;
         int borderColorStart = 0x505000FF;
         int borderColorEnd = (borderColorStart & 0xFEFEFE) >> 1 | borderColorStart & 0xFF000000;
-        RenderTooltipEvent.Color colorEvent = new RenderTooltipEvent.Color(ItemStack.EMPTY, lines, x, y, TextRenderer.getFontRenderer(), backgroundColor, borderColorStart, borderColorEnd);
+        RenderTooltipEvent.Color colorEvent = new RenderTooltipEvent.Color(stack, lines, x, y, TextRenderer.getFontRenderer(), backgroundColor, borderColorStart, borderColorEnd);
         MinecraftForge.EVENT_BUS.post(colorEvent);
         backgroundColor = colorEvent.getBackground();
         borderColorStart = colorEvent.getBorderStart();

--- a/src/main/java/com/cleanroommc/modularui/screen/Tooltip.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/Tooltip.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 public class Tooltip {
 
@@ -64,6 +65,10 @@ public class Tooltip {
     }
 
     public void draw(GuiContext context) {
+        draw(context, ItemStack.EMPTY);
+    }
+
+    public void draw(GuiContext context, @Nullable ItemStack stack) {
         if (updateTooltipEveryTick) {
             markDirty();
         }
@@ -72,12 +77,14 @@ public class Tooltip {
         if (maxWidth <= 0) {
             maxWidth = Integer.MAX_VALUE;
         }
+        if (stack == null) stack = ItemStack.EMPTY;
         Area screen = context.screen.getScreenArea();
         int mouseX = context.getAbsMouseX(), mouseY = context.getAbsMouseY();
         IconRenderer renderer = IconRenderer.SHARED;
         //List<IIcon> icons = renderer.measureLines(this.lines);
-        List<String> textLines = Collections.emptyList();//icons.stream().filter(iIcon -> iIcon instanceof TextIcon).map(icon -> ((TextIcon) icon).getText()).collect(Collectors.toList());
-        RenderTooltipEvent.Pre event = new RenderTooltipEvent.Pre(ItemStack.EMPTY, Collections.emptyList(), mouseX, mouseY, screen.width, screen.height, maxWidth, TextRenderer.getFontRenderer());
+        List<String> textLines = lines.stream().filter(drawable -> drawable instanceof IKey).map(key -> ((IKey) key).get()).collect(Collectors.toList());
+        //icons.stream().filter(iIcon -> iIcon instanceof TextIcon).map(icon -> ((TextIcon) icon).getText()).collect(Collectors.toList());
+        RenderTooltipEvent.Pre event = new RenderTooltipEvent.Pre(stack, textLines, mouseX, mouseY, screen.width, screen.height, maxWidth, TextRenderer.getFontRenderer());
         if (MinecraftForge.EVENT_BUS.post(event)) {
             return;
         }
@@ -106,9 +113,9 @@ public class Tooltip {
         GlStateManager.disableDepth();
         GlStateManager.disableBlend();
 
-        GuiDraw.drawTooltipBackground(textLines, area.x, area.y, area.width, area.height);
+        GuiDraw.drawTooltipBackground(stack, textLines, area.x, area.y, area.width, area.height);
 
-        MinecraftForge.EVENT_BUS.post(new RenderTooltipEvent.PostBackground(ItemStack.EMPTY, textLines, area.x, area.y, TextRenderer.getFontRenderer(), area.width, area.height));
+        MinecraftForge.EVENT_BUS.post(new RenderTooltipEvent.PostBackground(stack, textLines, area.x, area.y, TextRenderer.getFontRenderer(), area.width, area.height));
 
         GlStateManager.color(1f, 1f, 1f, 1f);
 
@@ -117,7 +124,7 @@ public class Tooltip {
         renderer.setPos(area.x, area.y);
         renderer.draw(context, this.lines);
 
-        MinecraftForge.EVENT_BUS.post(new RenderTooltipEvent.PostText(ItemStack.EMPTY, textLines, area.x, area.y, TextRenderer.getFontRenderer(), area.width, area.height));
+        MinecraftForge.EVENT_BUS.post(new RenderTooltipEvent.PostText(stack, textLines, area.x, area.y, TextRenderer.getFontRenderer(), area.width, area.height));
     }
 
     public Rectangle determineTooltipArea(GuiContext context, List<IDrawable> lines, IconRenderer renderer, int screenWidth, int screenHeight, int mouseX, int mouseY) {

--- a/src/main/java/com/cleanroommc/modularui/screen/Tooltip.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/Tooltip.java
@@ -23,7 +23,6 @@ import org.jetbrains.annotations.Nullable;
 
 import java.awt.*;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;

--- a/src/main/java/com/cleanroommc/modularui/widgets/ItemSlot.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/ItemSlot.java
@@ -9,6 +9,7 @@ import com.cleanroommc.modularui.drawable.GuiDraw;
 import com.cleanroommc.modularui.drawable.TextRenderer;
 import com.cleanroommc.modularui.integration.jei.JeiGhostIngredientSlot;
 import com.cleanroommc.modularui.integration.jei.JeiIngredientProvider;
+import com.cleanroommc.modularui.screen.Tooltip;
 import com.cleanroommc.modularui.screen.viewport.GuiContext;
 import com.cleanroommc.modularui.screen.GuiScreenWrapper;
 import com.cleanroommc.modularui.screen.ModularScreen;
@@ -144,6 +145,14 @@ public class ItemSlot extends Widget<ItemSlot> implements IVanillaSlot, Interact
     protected List<String> getItemTooltip(ItemStack stack) {
         // todo: JEI seems to be getting tooltip from IngredientRenderer#getTooltip
         return getScreen().getScreenWrapper().getItemToolTip(stack);
+    }
+
+    @Override
+    public void drawForeground(GuiContext context) {
+        Tooltip tooltip = getTooltip();
+        if (tooltip != null && isHoveringFor(tooltip.getShowUpTimer())) {
+            tooltip.draw(getContext(), getSlot().getStack());
+        }
     }
 
     @SideOnly(Side.CLIENT)


### PR DESCRIPTION
Fixes some mod compatibility issues that came from bad parameters being passed to `RenderTooltipEvent`s.

Makes two changes to tooltips:

- Tooltips now gather a list of all rendered text strings to pass to events.
- Tooltips can now optionally be given an `ItemStack` to pass on to events. (the `ItemSlot` widget uses this)