### PR TITLE
Allow transferItem to push to multiple slots (#5)

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
@@ -187,7 +187,9 @@ public class ModularContainer extends Container implements ISortableContainer {
                 } else {
                     slot.putStack(stack.splitStack(stack.getCount()));
                 }
-                break;
+                if (stack.getCount() < 1) {
+                    break;
+                }
             }
         }
         return stack;


### PR DESCRIPTION
In some situations, the slot stack size may be limited. Shift clicking a full stack can require multiple slots to be filled; this change adds a check for whether the slot can continue to be transferred.

(cherry picked from commit 6d744c4de11c1c50730763bbbaa30d761212c53c)