### PR TITLE
Allow theme to override some configs

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/api/ITheme.java
+++ b/src/main/java/com/cleanroommc/modularui/api/ITheme.java
@@ -50,4 +50,8 @@ public interface ITheme {
     WidgetToggleButtonTheme getToggleButtonTheme();
 
     WidgetTheme getWidgetTheme(String id);
+
+    int getOpenCloseAnimationOverride();
+
+    boolean getSmoothProgressBarOverride();
 }

--- a/src/main/java/com/cleanroommc/modularui/api/ITheme.java
+++ b/src/main/java/com/cleanroommc/modularui/api/ITheme.java
@@ -1,5 +1,6 @@
 package com.cleanroommc.modularui.api;
 
+import com.cleanroommc.modularui.screen.Tooltip;
 import com.cleanroommc.modularui.theme.WidgetSlotTheme;
 import com.cleanroommc.modularui.theme.WidgetTextFieldTheme;
 import com.cleanroommc.modularui.theme.WidgetTheme;
@@ -54,4 +55,6 @@ public interface ITheme {
     int getOpenCloseAnimationOverride();
 
     boolean getSmoothProgressBarOverride();
+
+    Tooltip.Pos getTooltipPosOverride();
 }

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularPanel.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularPanel.java
@@ -95,7 +95,7 @@ public class ModularPanel extends ParentWidget<ModularPanel> implements IViewpor
     }
 
     public void animateClose() {
-        if (ModularUIConfig.panelOpenCloseAnimationTime <= 0) {
+        if (getScreen().getCurrentTheme().getOpenCloseAnimationOverride() <= 0) {
             closeIfOpen();
             return;
         }
@@ -165,11 +165,12 @@ public class ModularPanel extends ParentWidget<ModularPanel> implements IViewpor
         this.screen = screen;
         getArea().z(1);
         initialise(this);
-        if (ModularUIConfig.panelOpenCloseAnimationTime <= 0) return;
+        int animationTime = getScreen().getCurrentTheme().getOpenCloseAnimationOverride();
+        if (animationTime <= 0) return;
         this.scale = 0.75f;
         this.alpha = 0f;
         if (this.animator == null) {
-            this.animator = new Animator(ModularUIConfig.panelOpenCloseAnimationTime, Interpolation.QUINT_OUT)
+            this.animator = new Animator(animationTime, Interpolation.QUINT_OUT)
                     .setValueBounds(0.0f, 1.0f)
                     .setCallback(val -> {
                         this.alpha = (float) val;

--- a/src/main/java/com/cleanroommc/modularui/screen/Tooltip.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/Tooltip.java
@@ -33,6 +33,7 @@ public class Tooltip {
     private List<IDrawable> additionalLines = new ArrayList<>();
     private Area excludeArea;
     private Pos pos = ModularUIConfig.tooltipPos;
+    private boolean customPos = false;
     private Consumer<Tooltip> tooltipBuilder;
     private int showUpTimer = 0;
 
@@ -127,6 +128,10 @@ public class Tooltip {
     public Rectangle determineTooltipArea(GuiContext context, List<IDrawable> lines, IconRenderer renderer, int screenWidth, int screenHeight, int mouseX, int mouseY) {
         int width = (int) renderer.getLastWidth();
         int height = (int) renderer.getLastHeight();
+
+        if (!this.customPos) {
+            this.pos = context.screen.getCurrentTheme().getTooltipPosOverride();
+        }
 
         if (this.pos == null) {
             return new Rectangle(this.x, this.y, width, height);
@@ -283,11 +288,13 @@ public class Tooltip {
     }
 
     public Tooltip pos(Pos pos) {
+        this.customPos = true;
         this.pos = pos;
         return this;
     }
 
     public Tooltip pos(int x, int y) {
+        this.customPos = true;
         this.pos = null;
         this.x = x;
         this.y = y;

--- a/src/main/java/com/cleanroommc/modularui/theme/AbstractDefaultTheme.java
+++ b/src/main/java/com/cleanroommc/modularui/theme/AbstractDefaultTheme.java
@@ -2,6 +2,7 @@ package com.cleanroommc.modularui.theme;
 
 import com.cleanroommc.modularui.ModularUIConfig;
 import com.cleanroommc.modularui.api.ITheme;
+import com.cleanroommc.modularui.screen.Tooltip;
 
 public abstract class AbstractDefaultTheme implements ITheme {
 
@@ -73,5 +74,10 @@ public abstract class AbstractDefaultTheme implements ITheme {
     @Override
     public boolean getSmoothProgressBarOverride() {
         return ModularUIConfig.smoothProgressBar;
+    }
+
+    @Override
+    public Tooltip.Pos getTooltipPosOverride() {
+        return ModularUIConfig.tooltipPos;
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/theme/AbstractDefaultTheme.java
+++ b/src/main/java/com/cleanroommc/modularui/theme/AbstractDefaultTheme.java
@@ -1,5 +1,6 @@
 package com.cleanroommc.modularui.theme;
 
+import com.cleanroommc.modularui.ModularUIConfig;
 import com.cleanroommc.modularui.api.ITheme;
 
 public abstract class AbstractDefaultTheme implements ITheme {
@@ -62,5 +63,15 @@ public abstract class AbstractDefaultTheme implements ITheme {
             this.toggleButtonTheme = (WidgetToggleButtonTheme) getWidgetTheme(Theme.TOGGLE_BUTTON);
         }
         return this.toggleButtonTheme;
+    }
+
+    @Override
+    public int getOpenCloseAnimationOverride() {
+        return ModularUIConfig.panelOpenCloseAnimationTime;
+    }
+
+    @Override
+    public boolean getSmoothProgressBarOverride() {
+        return ModularUIConfig.smoothProgressBar;
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/theme/Theme.java
+++ b/src/main/java/com/cleanroommc/modularui/theme/Theme.java
@@ -1,5 +1,6 @@
 package com.cleanroommc.modularui.theme;
 
+import com.cleanroommc.modularui.ModularUIConfig;
 import com.cleanroommc.modularui.api.ITheme;
 import com.cleanroommc.modularui.api.IThemeApi;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
@@ -28,6 +29,9 @@ public class Theme implements ITheme {
     private final WidgetTextFieldTheme textFieldTheme;
     private final WidgetToggleButtonTheme toggleButtonTheme;
 
+    private int openCloseAnimationOverride = -1;
+    private Boolean smoothProgressBarOverride = null;
+
     Theme(String id, ITheme parent, Map<String, WidgetTheme> widgetThemes) {
         this.id = id;
         this.parentTheme = parent;
@@ -55,6 +59,14 @@ public class Theme implements ITheme {
         this.fluidSlotTheme = (WidgetSlotTheme) this.widgetThemes.get(FLUID_SLOT);
         this.textFieldTheme = (WidgetTextFieldTheme) this.widgetThemes.get(TEXT_FIELD);
         this.toggleButtonTheme = (WidgetToggleButtonTheme) this.widgetThemes.get(TOGGLE_BUTTON);
+    }
+
+    void setOpenCloseAnimationOverride(int override) {
+        this.openCloseAnimationOverride = override;
+    }
+
+    void setSmoothProgressBarOverride(boolean smooth) {
+        this.smoothProgressBarOverride = smooth;
     }
 
     public String getId() {
@@ -101,5 +113,21 @@ public class Theme implements ITheme {
             return this.widgetThemes.get(id);
         }
         return getFallback();
+    }
+
+    @Override
+    public int getOpenCloseAnimationOverride() {
+        if (this.openCloseAnimationOverride != -1) {
+            return this.openCloseAnimationOverride;
+        }
+        return ModularUIConfig.panelOpenCloseAnimationTime;
+    }
+
+    @Override
+    public boolean getSmoothProgressBarOverride() {
+        if (this.smoothProgressBarOverride != null) {
+            return this.smoothProgressBarOverride;
+        }
+        return ModularUIConfig.smoothProgressBar;
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/theme/Theme.java
+++ b/src/main/java/com/cleanroommc/modularui/theme/Theme.java
@@ -3,6 +3,7 @@ package com.cleanroommc.modularui.theme;
 import com.cleanroommc.modularui.ModularUIConfig;
 import com.cleanroommc.modularui.api.ITheme;
 import com.cleanroommc.modularui.api.IThemeApi;
+import com.cleanroommc.modularui.screen.Tooltip;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 
 import java.util.Map;
@@ -31,6 +32,7 @@ public class Theme implements ITheme {
 
     private int openCloseAnimationOverride = -1;
     private Boolean smoothProgressBarOverride = null;
+    private Tooltip.Pos tooltipPosOverride = null;
 
     Theme(String id, ITheme parent, Map<String, WidgetTheme> widgetThemes) {
         this.id = id;
@@ -67,6 +69,10 @@ public class Theme implements ITheme {
 
     void setSmoothProgressBarOverride(boolean smooth) {
         this.smoothProgressBarOverride = smooth;
+    }
+
+    void setTooltipPosOverride(Tooltip.Pos pos) {
+        this.tooltipPosOverride = pos;
     }
 
     public String getId() {
@@ -129,5 +135,13 @@ public class Theme implements ITheme {
             return this.smoothProgressBarOverride;
         }
         return ModularUIConfig.smoothProgressBar;
+    }
+
+    @Override
+    public Tooltip.Pos getTooltipPosOverride() {
+        if (this.tooltipPosOverride != null) {
+            return this.tooltipPosOverride;
+        }
+        return ModularUIConfig.tooltipPos;
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/theme/ThemeManager.java
+++ b/src/main/java/com/cleanroommc/modularui/theme/ThemeManager.java
@@ -274,7 +274,14 @@ public class ThemeManager implements ISelectiveResourceReloadListener {
                 parentWidgetTheme = parent.getWidgetTheme(entry.getKey());
                 widgetThemes.put(entry.getKey(), entry.getValue().parse(parentWidgetTheme, widgetThemeJson, jsonBuilder.getJson()));
             }
-            return new Theme(this.id, parent, widgetThemes);
+            Theme theme = new Theme(this.id, parent, widgetThemes);
+            if (jsonBuilder.getJson().has("openCloseAnimation")) {
+                theme.setOpenCloseAnimationOverride(jsonBuilder.getJson().get("openCloseAnimation").getAsInt());
+            }
+            if (jsonBuilder.getJson().has("smoothProgressBar")) {
+                theme.setSmoothProgressBarOverride(jsonBuilder.getJson().get("smoothProgressBar").getAsBoolean());
+            }
+            return theme;
         }
     }
 

--- a/src/main/java/com/cleanroommc/modularui/theme/ThemeManager.java
+++ b/src/main/java/com/cleanroommc/modularui/theme/ThemeManager.java
@@ -2,6 +2,7 @@ package com.cleanroommc.modularui.theme;
 
 import com.cleanroommc.modularui.ModularUI;
 import com.cleanroommc.modularui.api.ITheme;
+import com.cleanroommc.modularui.screen.Tooltip;
 import com.cleanroommc.modularui.utils.*;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -280,6 +281,10 @@ public class ThemeManager implements ISelectiveResourceReloadListener {
             }
             if (jsonBuilder.getJson().has("smoothProgressBar")) {
                 theme.setSmoothProgressBarOverride(jsonBuilder.getJson().get("smoothProgressBar").getAsBoolean());
+            }
+            if (jsonBuilder.getJson().has("tooltipPos")) {
+                String posName = jsonBuilder.getJson().get("tooltipPos").getAsString();
+                theme.setTooltipPosOverride(Tooltip.Pos.valueOf(posName));
             }
             return theme;
         }

--- a/src/main/java/com/cleanroommc/modularui/widgets/ProgressWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/ProgressWidget.java
@@ -98,7 +98,7 @@ public class ProgressWidget extends Widget<ProgressWidget> {
     }
 
     public float getProgressUV(float uv) {
-        if (ModularUIConfig.smoothProgressBar) {
+        if (getScreen().getCurrentTheme().getSmoothProgressBarOverride()) {
             return uv;
         }
         return (float) (Math.floor(uv * this.imageSize) / this.imageSize);

--- a/src/main/resources/assets/modularui/themes/vanilla_dark.json
+++ b/src/main/resources/assets/modularui/themes/vanilla_dark.json
@@ -1,6 +1,5 @@
 {
   "color": "0x444444",
   "textColor": "0xEEEEEE",
-  "textShadow": false,
-  "tooltipPos": "NEXT_TO_MOUSE"
+  "textShadow": false
 }

--- a/src/main/resources/assets/modularui/themes/vanilla_dark.json
+++ b/src/main/resources/assets/modularui/themes/vanilla_dark.json
@@ -1,5 +1,6 @@
 {
   "color": "0x444444",
   "textColor": "0xEEEEEE",
-  "textShadow": false
+  "textShadow": false,
+  "tooltipPos": "NEXT_TO_MOUSE"
 }


### PR DESCRIPTION
Allows theme json to override `panelOpenCloseAnimationTime`,`smoothProgressBar` and `tooltipPos` global values