### PR TITLE
Fix UI close crash

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/ClientEventHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/ClientEventHandler.java
@@ -67,10 +67,15 @@ public class ClientEventHandler {
             // queue the screen to open it on next tick
             if (event.getGui() != null) {
                 ClientGUI.open(event.getGui());
+                event.setCanceled(true);
             } else {
-                ClientGUI.close();
+                // clear any queued-for-opening screen if needed otherwise, just
+                // in case someone tries to close the screen before we actually
+                // open it. If that clears the queue, then we cancel the event.
+                if (GuiManager.resetState()) {
+                    event.setCanceled(true);
+                }
             }
-            event.setCanceled(true);
         }
     }
 

--- a/src/main/java/com/cleanroommc/modularui/factory/ClientGUI.java
+++ b/src/main/java/com/cleanroommc/modularui/factory/ClientGUI.java
@@ -50,7 +50,7 @@ public class ClientGUI {
     }
 
     /**
-     * Closes any GUI that is open in the next client tick.
+     * Closes any GUI that is open in this tick.
      */
     public static void close() {
         GuiManager.closeScreen();

--- a/src/main/java/com/cleanroommc/modularui/factory/GuiManager.java
+++ b/src/main/java/com/cleanroommc/modularui/factory/GuiManager.java
@@ -19,6 +19,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import io.netty.buffer.Unpooled;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.jetbrains.annotations.ApiStatus;
 
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -29,7 +30,6 @@ public class GuiManager {
     private static ModularScreen queuedClientScreen;
     private static JeiSettingsImpl queuedJeiSettings;
     private static GuiScreen queuedGuiScreen;
-    private static boolean closeScreen;
     private static boolean openingQueue = false;
 
     public static void registerFactory(UIFactory<?> factory) {
@@ -94,13 +94,8 @@ public class GuiManager {
             Minecraft.getMinecraft().displayGuiScreen(screenWrapper);
         } else if (queuedGuiScreen != null) {
             Minecraft.getMinecraft().displayGuiScreen(queuedGuiScreen);
-        } else if (closeScreen) {
-            Minecraft.getMinecraft().displayGuiScreen(null);
         }
-        queuedClientScreen = null;
-        queuedJeiSettings = null;
-        queuedGuiScreen = null;
-        closeScreen = false;
+        resetState();
         openingQueue = false;
     }
 
@@ -109,7 +104,6 @@ public class GuiManager {
         queuedClientScreen = screen;
         queuedJeiSettings = jeiSettings;
         queuedGuiScreen = null;
-        closeScreen = false;
     }
 
     @SideOnly(Side.CLIENT)
@@ -117,15 +111,24 @@ public class GuiManager {
         queuedClientScreen = null;
         queuedJeiSettings = null;
         queuedGuiScreen = screen;
-        closeScreen = false;
     }
 
     @SideOnly(Side.CLIENT)
     static void closeScreen() {
-        queuedClientScreen = null;
-        queuedJeiSettings = null;
-        queuedGuiScreen = null;
-        closeScreen = true;
+        Minecraft.getMinecraft().displayGuiScreen(null);
+        resetState();
+    }
+
+    @ApiStatus.Internal
+    @SideOnly(Side.CLIENT)
+    public static boolean resetState() {
+        if (queuedClientScreen != null || queuedGuiScreen != null) {
+            queuedClientScreen = null;
+            queuedJeiSettings = null;
+            queuedGuiScreen = null;
+            return true;
+        }
+        return false;
     }
 
     public static boolean isOpeningQueue() {

--- a/src/main/java/com/cleanroommc/modularui/network/packets/OpenGuiPacket.java
+++ b/src/main/java/com/cleanroommc/modularui/network/packets/OpenGuiPacket.java
@@ -10,6 +10,8 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.network.NetHandlerPlayClient;
 import net.minecraft.network.PacketBuffer;
 
+import net.minecraftforge.fml.relauncher.Side;
+import net.minecraftforge.fml.relauncher.SideOnly;
 import org.jetbrains.annotations.Nullable;
 
 import java.io.IOException;
@@ -43,6 +45,7 @@ public class OpenGuiPacket<T extends GuiData> implements IPacket {
         this.data = NetworkUtils.readPacketBuffer(buf);
     }
 
+    @SideOnly(Side.CLIENT)
     @Override
     public @Nullable IPacket executeClient(NetHandlerPlayClient handler) {
         GuiManager.open(this.windowId, this.factory, this.data, Minecraft.getMinecraft().player);


### PR DESCRIPTION
MUI schedules UIs for opening 1 tick later (I'm not 100% sure on the reason for this, but I figure its important).

However, closing UIs 1 tick later causes the MUI panel state to be set as inactive/invalid before the window closes (in some cases, I'll explain below). Now we immediately close the UI, or pop the queued UI off the queue if there is one.

This seemed like a race condition or similar with the UI close animation because if that animation caused the panel to cross over into another tick (i.e., the `esc` input is inputted in tick 50, but the animation ends in tick 51) then the crash would not occur.