### PR TITLE
Close top panel instead of all panels on Esc/E

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/screen/GuiScreenWrapper.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/GuiScreenWrapper.java
@@ -374,7 +374,15 @@ public class GuiScreenWrapper extends GuiContainer {
             return;
         }
         if (keyCode == 1 || this.mc.gameSettings.keyBindInventory.isActiveAndMatches(keyCode)) {
-            this.screen.closeTopPanel();
+            GuiContext context = this.screen.getContext();
+            if (context.hasDraggable()) {
+                // drop the dragged element first if escape/e is hit
+                context.dropDraggable();
+            } else {
+                // close the top-most panel next if escape/e is hit
+                // this will also handle closing the UI if the main panel is top-most
+                this.screen.closeTopPanel();
+            }
         }
 
         this.checkHotbarKeys(keyCode);

--- a/src/main/java/com/cleanroommc/modularui/screen/GuiScreenWrapper.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/GuiScreenWrapper.java
@@ -374,7 +374,7 @@ public class GuiScreenWrapper extends GuiContainer {
             return;
         }
         if (keyCode == 1 || this.mc.gameSettings.keyBindInventory.isActiveAndMatches(keyCode)) {
-            this.screen.close();
+            this.screen.closeTopPanel();
         }
 
         this.checkHotbarKeys(keyCode);

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularScreen.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularScreen.java
@@ -183,6 +183,10 @@ public class ModularScreen {
         this.windowManager.openPanel(panel);
     }
 
+    public void closeTopPanel() {
+        this.windowManager.closeTopPanel();
+    }
+
     public void closePanel(ModularPanel panel) {
         this.windowManager.closePanel(panel);
     }

--- a/src/main/java/com/cleanroommc/modularui/screen/WindowManager.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/WindowManager.java
@@ -162,11 +162,7 @@ public class WindowManager {
     public void closeTopPanel() {
         ModularPanel panel = getTopMostPanel();
         if (panel != null) {
-            if (panel == mainPanel) {
-                panel.animateClose();
-            } else {
-                closePanel(panel);
-            }
+            panel.animateClose();
         }
     }
 

--- a/src/main/java/com/cleanroommc/modularui/screen/WindowManager.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/WindowManager.java
@@ -161,7 +161,13 @@ public class WindowManager {
 
     public void closeTopPanel() {
         ModularPanel panel = getTopMostPanel();
-        if (panel != null) closePanel(panel);
+        if (panel != null) {
+            if (panel == mainPanel) {
+                panel.animateClose();
+            } else {
+                closePanel(panel);
+            }
+        }
     }
 
     public void closeAll() {

--- a/src/main/java/com/cleanroommc/modularui/screen/WindowManager.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/WindowManager.java
@@ -159,14 +159,9 @@ public class WindowManager {
         }
     }
 
-    public void closeTopPanel(boolean alsoCloseMain, boolean animate) {
+    public void closeTopPanel() {
         ModularPanel panel = getTopMostPanel();
-        if (panel == getMainPanel() && !alsoCloseMain) return;
-        if (animate) {
-            panel.animateClose();
-            return;
-        }
-        panel.closeIfOpen();
+        if (panel != null) closePanel(panel);
     }
 
     public void closeAll() {

--- a/src/main/java/com/cleanroommc/modularui/screen/viewport/GuiContext.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/viewport/GuiContext.java
@@ -278,7 +278,8 @@ public class GuiContext extends GuiViewportStack {
         return false;
     }
 
-    private void dropDraggable() {
+    @ApiStatus.Internal
+    public void dropDraggable() {
         this.draggable.applyMatrix(this);
         this.draggable.getElement().onDragEnd(this.draggable.getElement().canDropHere(getAbsMouseX(), getAbsMouseY(), this.hovered));
         this.draggable.getElement().setMoving(false);


### PR DESCRIPTION
I refactored the `closeTopPanel()` method on `WindowManager` because it was unused. I can change it to leave that signature if you'd prefer