### PR TITLE
Screen & panel close refactor

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/ClientEventHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/ClientEventHandler.java
@@ -49,20 +49,12 @@ public class ClientEventHandler {
     }
 
     @SubscribeEvent
-    public static void onClientTick(TickEvent.ClientTickEvent event) {
-        if (event.phase == TickEvent.Phase.START) {
-            ticks++;
-            GuiManager.checkQueuedScreen();
-        }
-    }
-
-    @SubscribeEvent
     public static void onOpenScreen(GuiOpenEvent event) {
         if (event.getGui() instanceof GuiScreenWrapper && Minecraft.getMinecraft().currentScreen != null) {
             // another screen is already open, don't fade in the dark background as it's already there
             ((GuiScreenWrapper) event.getGui()).setDoAnimateTransition(false);
         }
-        if (!GuiManager.isOpeningQueue() && Minecraft.getMinecraft().currentScreen instanceof GuiScreenWrapper) {
+        /*if (!GuiManager.isOpeningQueue() && Minecraft.getMinecraft().currentScreen instanceof GuiScreenWrapper) {
             // opening a screen while a modular screen is open can cause crashes
             // queue the screen to open it on next tick
             if (event.getGui() != null) {
@@ -76,7 +68,7 @@ public class ClientEventHandler {
                     event.setCanceled(true);
                 }
             }
-        }
+        }*/
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)

--- a/src/main/java/com/cleanroommc/modularui/ClientEventHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/ClientEventHandler.java
@@ -1,13 +1,9 @@
 package com.cleanroommc.modularui;
 
 import com.cleanroommc.modularui.drawable.Stencil;
-import com.cleanroommc.modularui.factory.ClientGUI;
-import com.cleanroommc.modularui.factory.GuiManager;
 import com.cleanroommc.modularui.screen.GuiScreenWrapper;
 import com.cleanroommc.modularui.screen.ModularScreen;
 
-import net.minecraft.client.Minecraft;
-import net.minecraftforge.client.event.GuiOpenEvent;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
@@ -46,29 +42,6 @@ public class ClientEventHandler {
             GL11.glEnable(GL11.GL_STENCIL_TEST);
         }
         Stencil.reset();
-    }
-
-    @SubscribeEvent
-    public static void onOpenScreen(GuiOpenEvent event) {
-        if (event.getGui() instanceof GuiScreenWrapper && Minecraft.getMinecraft().currentScreen != null) {
-            // another screen is already open, don't fade in the dark background as it's already there
-            ((GuiScreenWrapper) event.getGui()).setDoAnimateTransition(false);
-        }
-        /*if (!GuiManager.isOpeningQueue() && Minecraft.getMinecraft().currentScreen instanceof GuiScreenWrapper) {
-            // opening a screen while a modular screen is open can cause crashes
-            // queue the screen to open it on next tick
-            if (event.getGui() != null) {
-                ClientGUI.open(event.getGui());
-                event.setCanceled(true);
-            } else {
-                // clear any queued-for-opening screen if needed otherwise, just
-                // in case someone tries to close the screen before we actually
-                // open it. If that clears the queue, then we cancel the event.
-                if (GuiManager.resetState()) {
-                    event.setCanceled(true);
-                }
-            }
-        }*/
     }
 
     @SubscribeEvent(priority = EventPriority.HIGHEST)

--- a/src/main/java/com/cleanroommc/modularui/ClientProxy.java
+++ b/src/main/java/com/cleanroommc/modularui/ClientProxy.java
@@ -1,6 +1,7 @@
 package com.cleanroommc.modularui;
 
 import com.cleanroommc.modularui.drawable.DrawableSerialization;
+import com.cleanroommc.modularui.factory.GuiManager;
 import com.cleanroommc.modularui.holoui.HoloScreenEntity;
 import com.cleanroommc.modularui.holoui.ScreenEntityRender;
 import com.cleanroommc.modularui.keybind.KeyBindHandler;
@@ -30,6 +31,7 @@ public class ClientProxy extends CommonProxy {
         super.preInit(event);
 
         MinecraftForge.EVENT_BUS.register(ClientEventHandler.class);
+        MinecraftForge.EVENT_BUS.register(GuiManager.class);
         MinecraftForge.EVENT_BUS.register(KeyBindHandler.class);
 
         if (ModularUIConfig.enabledTestGuis) {

--- a/src/main/java/com/cleanroommc/modularui/factory/ClientGUI.java
+++ b/src/main/java/com/cleanroommc/modularui/factory/ClientGUI.java
@@ -3,6 +3,7 @@ package com.cleanroommc.modularui.factory;
 import com.cleanroommc.modularui.screen.JeiSettingsImpl;
 import com.cleanroommc.modularui.screen.ModularScreen;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
@@ -45,14 +46,14 @@ public class ClientGUI {
      *
      * @param screen screen to open
      */
-    public static void open(@NotNull GuiScreen screen) {
-        GuiManager.openScreen(screen);
+    public static void open(GuiScreen screen) {
+        Minecraft.getMinecraft().displayGuiScreen(screen);
     }
 
     /**
      * Closes any GUI that is open in this tick.
      */
     public static void close() {
-        GuiManager.closeScreen();
+        Minecraft.getMinecraft().displayGuiScreen(null);
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/factory/GuiManager.java
+++ b/src/main/java/com/cleanroommc/modularui/factory/GuiManager.java
@@ -21,7 +21,6 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import io.netty.buffer.Unpooled;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-import org.jetbrains.annotations.ApiStatus;
 
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -106,6 +105,9 @@ public class GuiManager {
     @SubscribeEvent
     public static void onGuiOpen(GuiOpenEvent event) {
         if (lastMui != null && event.getGui() == null) {
+            if (lastMui.getScreen().getPanelManager().isOpen()) {
+                lastMui.getScreen().getPanelManager().closeAll();
+            }
             lastMui.getScreen().getPanelManager().dispose();
             lastMui = null;
         } else if (event.getGui() instanceof GuiScreenWrapper) {
@@ -114,6 +116,9 @@ public class GuiManager {
             } else if (lastMui == event.getGui()) {
                 lastMui.getScreen().getPanelManager().reopen();
             } else {
+                if (lastMui.getScreen().getPanelManager().isOpen()) {
+                    lastMui.getScreen().getPanelManager().closeAll();
+                }
                 lastMui.getScreen().getPanelManager().dispose();
                 lastMui = (GuiScreenWrapper) event.getGui();
             }

--- a/src/main/java/com/cleanroommc/modularui/factory/GuiManager.java
+++ b/src/main/java/com/cleanroommc/modularui/factory/GuiManager.java
@@ -10,7 +10,6 @@ import com.cleanroommc.modularui.widget.WidgetTree;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
-import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.network.PacketBuffer;
 import net.minecraftforge.client.event.GuiOpenEvent;
@@ -21,6 +20,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import io.netty.buffer.Unpooled;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -43,13 +43,13 @@ public class GuiManager {
         FACTORIES.put(name, factory);
     }
 
-    public static UIFactory<?> getFactory(String name) {
+    public static @NotNull UIFactory<?> getFactory(String name) {
         UIFactory<?> factory = FACTORIES.get(name);
         if (factory == null) throw new NoSuchElementException();
         return factory;
     }
 
-    public static <T extends GuiData> void open(UIFactory<T> factory, T guiData, EntityPlayerMP player) {
+    public static <T extends GuiData> void open(@NotNull UIFactory<T> factory, @NotNull T guiData, EntityPlayerMP player) {
         // create panel, collect sync handlers and create container
         guiData.setJeiSettings(JeiSettings.DUMMY);
         GuiSyncManager syncManager = new GuiSyncManager(player);
@@ -70,7 +70,7 @@ public class GuiManager {
     }
 
     @SideOnly(Side.CLIENT)
-    public static <T extends GuiData> void open(int windowId, UIFactory<T> factory, PacketBuffer data, EntityPlayerSP player) {
+    public static <T extends GuiData> void open(int windowId, @NotNull UIFactory<T> factory, @NotNull PacketBuffer data, @NotNull EntityPlayerSP player) {
         T guiData = factory.readGuiData(player, data);
         JeiSettingsImpl jeiSettings = new JeiSettingsImpl();
         guiData.setJeiSettings(jeiSettings);
@@ -90,17 +90,6 @@ public class GuiManager {
         GuiScreenWrapper screenWrapper = new GuiScreenWrapper(new ModularContainer(), screen);
         Minecraft.getMinecraft().displayGuiScreen(screenWrapper);
     }
-
-    @SideOnly(Side.CLIENT)
-    static void openScreen(GuiScreen screen) {
-        Minecraft.getMinecraft().displayGuiScreen(screen);
-    }
-
-    @SideOnly(Side.CLIENT)
-    static void closeScreen() {
-        Minecraft.getMinecraft().displayGuiScreen(null);
-    }
-
 
     @SubscribeEvent
     public static void onGuiOpen(GuiOpenEvent event) {

--- a/src/main/java/com/cleanroommc/modularui/screen/GuiScreenWrapper.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/GuiScreenWrapper.java
@@ -50,7 +50,6 @@ public class GuiScreenWrapper extends GuiContainer {
 
     private int fps, frameCount = 0;
     private long timer = Minecraft.getSystemTime();
-    private boolean doAnimateTransition = true;
 
     public GuiScreenWrapper(ModularContainer container, ModularScreen screen) {
         super(container);
@@ -189,7 +188,7 @@ public class GuiScreenWrapper extends GuiContainer {
             super.drawWorldBackground(tint);
             return;
         }
-        float alpha = this.doAnimateTransition ? this.screen.getMainPanel().getAlpha() : 1f;
+        float alpha = this.screen.getMainPanel().getAlpha();
         // vanilla color values as hex
         int color = 0x101010;
         int startAlpha = 0xc0;
@@ -300,7 +299,6 @@ public class GuiScreenWrapper extends GuiContainer {
         super.onGuiClosed();
         this.screen.onClose();
         this.init = true;
-        this.doAnimateTransition = true;
     }
 
     public ModularScreen getScreen() {
@@ -373,7 +371,11 @@ public class GuiScreenWrapper extends GuiContainer {
             return;
         }
         if (keyCode == 1 || this.mc.gameSettings.keyBindInventory.isActiveAndMatches(keyCode)) {
-            this.screen.close();
+            if (this.screen.getContext().hasDraggable()) {
+                this.screen.getContext().dropDraggable();
+            } else {
+                this.screen.getPanelManager().closeTopPanel(true);
+            }
         }
 
         this.checkHotbarKeys(keyCode);
@@ -409,13 +411,5 @@ public class GuiScreenWrapper extends GuiContainer {
 
     public FontRenderer getFontRenderer() {
         return this.fontRenderer;
-    }
-
-    public void setDoAnimateTransition(boolean doAnimateTransition) {
-        this.doAnimateTransition = doAnimateTransition;
-    }
-
-    public boolean doAnimateTransition() {
-        return doAnimateTransition;
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/screen/GuiScreenWrapper.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/GuiScreenWrapper.java
@@ -63,7 +63,6 @@ public class GuiScreenWrapper extends GuiContainer {
         GuiErrorHandler.INSTANCE.clear();
         super.initGui();
         if (this.init) {
-            this.screen.getWindowManager().resetClosed();
             this.screen.onOpen();
             this.init = false;
         }
@@ -230,7 +229,7 @@ public class GuiScreenWrapper extends GuiContainer {
         drawString(this.fontRenderer, "Mouse Pos: " + mouseX + ", " + mouseY, 5, lineY, color);
         lineY -= 11;
         drawString(this.fontRenderer, "FPS: " + this.fps, 5, screenH - 24, color);
-        LocatedWidget locatedHovered = this.screen.getWindowManager().getTopWidgetLocated(true);
+        LocatedWidget locatedHovered = this.screen.getPanelManager().getTopWidgetLocated(true);
         if (locatedHovered != null) {
             drawSegmentLine(lineY -= 4, color);
             lineY -= 10;

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularPanel.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularPanel.java
@@ -240,6 +240,7 @@ public class ModularPanel extends ParentWidget<ModularPanel> implements IViewpor
      */
     public final <T> T doSafe(Supplier<T> runnable) {
         if (this.state == State.DISPOSED) return null;
+        // make sure the screen is also not disposed
         return getScreen().getPanelManager().doSafe(() -> {
             this.cantDisposeNow = true;
             T t = runnable.get();

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularPanel.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularPanel.java
@@ -203,7 +203,6 @@ public class ModularPanel extends ParentWidget<ModularPanel> implements IViewpor
 
     @MustBeInvokedByOverriders
     public void onClose() {
-        //dispose();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularScreen.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularScreen.java
@@ -164,7 +164,6 @@ public class ModularScreen {
     public void close(boolean force) {
         if (isActive()) {
             if (force) {
-                getPanelManager().closeAll();
                 this.context.mc.player.closeScreen();
                 return;
             }

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularScreen.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularScreen.java
@@ -164,6 +164,7 @@ public class ModularScreen {
     public void close(boolean force) {
         if (isActive()) {
             if (force) {
+                getPanelManager().closeAll();
                 this.context.mc.player.closeScreen();
                 return;
             }

--- a/src/main/java/com/cleanroommc/modularui/screen/PanelManager.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/PanelManager.java
@@ -6,6 +6,7 @@ import com.cleanroommc.modularui.utils.ObjectList;
 import com.cleanroommc.modularui.utils.ReverseIterable;
 import com.cleanroommc.modularui.widget.WidgetTree;
 
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnmodifiableView;
@@ -15,68 +16,47 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
-public class WindowManager {
+public class PanelManager {
 
     private final ModularScreen screen;
     /**
      * At least one panel must exist always exist.
      * If this panel is closed, all panels will close.
      */
-    private ModularPanel mainPanel;
+    private final ModularPanel mainPanel;
     /**
      * List of all open panels from top to bottom.
      */
     private final ObjectList<ModularPanel> panels = ObjectList.create();
-    private final List<ModularPanel> panelsView = Collections.unmodifiableList(this.panels);
+    private final List<ModularPanel> panelsClone = new ArrayList<>();
+    private final List<ModularPanel> panelsView = Collections.unmodifiableList(this.panelsClone);
     private final ReverseIterable<ModularPanel> reversePanels = new ReverseIterable<>(this.panelsView);
-    private final List<ModularPanel> queueOpenPanels = new ArrayList<>();
-    private final List<ModularPanel> queueClosePanels = new ArrayList<>();
-    private boolean isScreenClosing = false;
-    private boolean closed;
+    private boolean dirty = false;
+    private State state = State.INIT;
 
-    public WindowManager(ModularScreen screen) {
+    public PanelManager(ModularScreen screen, ModularPanel panel) {
         this.screen = screen;
-    }
-
-    void construct(ModularPanel panel) {
-        if (this.mainPanel != null) {
-            throw new IllegalStateException();
-        }
         this.mainPanel = Objects.requireNonNull(panel, "Main panel must not be null!");
     }
 
     void init() {
-        if (this.mainPanel == null) {
-            throw new IllegalStateException("WindowManager is not yet constructed!");
+        if (this.state == State.CLOSED) throw new IllegalStateException("Can't init in closed state!");
+        if (this.state == State.INIT || this.state == State.DISPOSED) {
+            this.state = State.OPEN;
+            openPanel(this.mainPanel, false);
+            checkDirty();
         }
-        openPanel(this.mainPanel, false);
     }
 
     public boolean isMainPanel(ModularPanel panel) {
         return this.mainPanel == panel;
     }
 
-    void clearQueue() {
-        if (!this.queueOpenPanels.isEmpty()) {
-            for (ModularPanel panel : this.queueOpenPanels) {
-                openPanel(panel, true);
-            }
-            this.queueOpenPanels.clear();
-        }
-
-        if (!this.queueClosePanels.isEmpty()) {
-            if (this.queueClosePanels.contains(this.mainPanel)) {
-                closeAll();
-                this.screen.close(true);
-            } else {
-                for (ModularPanel panel : this.queueClosePanels) {
-                    if (!this.panels.contains(panel)) throw new IllegalStateException();
-                    if (this.panels.remove(panel)) {
-                        panel.onClose();
-                    }
-                }
-            }
-            this.queueClosePanels.clear();
+    void checkDirty() {
+        if (this.dirty) {
+            this.panelsClone.clear();
+            this.panelsClone.addAll(this.panels);
+            this.dirty = false;
         }
     }
 
@@ -89,6 +69,7 @@ public class WindowManager {
         }
         panel.setPanelGuiContext(this.screen.getContext());
         this.panels.addFirst(panel);
+        this.dirty = true;
         panel.getArea().setPanelLayer((byte) this.panels.size());
         panel.onOpen(this.screen);
         if (resize) {
@@ -112,11 +93,8 @@ public class WindowManager {
 
     @NotNull
     public ModularPanel getMainPanel() {
-        if (this.mainPanel == null) {
-            throw new IllegalStateException("WindowManager has not been initialised yet!");
-        }
-        if (this.closed) {
-            throw new IllegalStateException("Screen has been closed");
+        if (isDisposed()) {
+            throw new IllegalStateException("Screen has been disposed");
         }
         return this.mainPanel;
     }
@@ -148,14 +126,21 @@ public class WindowManager {
     }
 
     public void openPanel(@NotNull ModularPanel panel) {
-        if (!this.queueOpenPanels.contains(panel)) {
-            this.queueOpenPanels.add(panel);
-        }
+        openPanel(panel, true);
     }
 
     public void closePanel(@NotNull ModularPanel panel) {
-        if (!this.queueClosePanels.contains(panel)) {
-            this.queueClosePanels.add(panel);
+        if (!hasOpenPanel(panel)) {
+            throw new IllegalArgumentException("Panel '" + panel.getName() + "' is open in this screen!");
+        }
+        if (panel == getMainPanel()) {
+            closeAll();
+            this.screen.close(true);
+            return;
+        }
+        if (this.panels.remove(panel)) {
+            panel.onClose();
+            this.dirty = true;
         }
     }
 
@@ -170,12 +155,36 @@ public class WindowManager {
     }
 
     public void closeAll() {
-        this.isScreenClosing = true;
         for (ModularPanel panel : this.panels) {
             panel.onClose();
         }
+        // this.panels.clear();
+        // this.dirty = true;
+        this.state = State.CLOSED;
+    }
+
+    @ApiStatus.Internal
+    public void dispose() {
+        if (!isClosed()) throw new IllegalStateException("Must close screen first before disposing!");
+        for (ModularPanel panel : this.panels) {
+            panel.dispose();
+        }
         this.panels.clear();
-        this.closed = true;
+        this.panelsClone.clear();
+        this.dirty = false;
+        this.state = State.DISPOSED;
+    }
+
+    @ApiStatus.Internal
+    public void reopen() {
+        if (this.panels.isEmpty()) {
+            throw new IllegalStateException("Screen is disposed. Can't be recovered!");
+        }
+        this.state = State.REOPENED;
+    }
+
+    public boolean hasOpenPanel(ModularPanel panel) {
+        return this.panels.contains(panel);
     }
 
     public void pushUp(@NotNull ModularPanel window) {
@@ -213,33 +222,50 @@ public class WindowManager {
     @NotNull
     @UnmodifiableView
     public List<ModularPanel> getOpenPanels() {
+        checkDirty();
         return this.panelsView;
     }
 
     @NotNull
     @UnmodifiableView
     public Iterable<ModularPanel> getReverseOpenPanels() {
+        checkDirty();
         return this.reversePanels;
     }
 
     public boolean isClosed() {
-        return this.closed;
+        return this.state == State.CLOSED || this.state == State.DISPOSED;
     }
 
-    void resetClosed() {
-        this.closed = false;
+    public boolean isDisposed() {
+        return this.state == State.DISPOSED;
     }
 
-    public boolean isAboutToClose(ModularPanel panel) {
-        for (ModularPanel panel1 : this.queueClosePanels) {
-            if (panel == panel1) {
-                return true;
-            }
+    public boolean isOpen() {
+        return this.state.isOpen;
+    }
+
+    public boolean isReopened() {
+        return this.state == State.REOPENED;
+    }
+
+    private void checkDisposed() {
+        if (isDisposed()) {
+            throw new IllegalStateException("Screen is disposed!");
         }
-        return false;
     }
 
-    public boolean isScreenClosing() {
-        return this.isScreenClosing;
+    public enum State {
+        INIT(false),
+        OPEN(true),
+        REOPENED(true),
+        CLOSED(false),
+        DISPOSED(false);
+
+        public final boolean isOpen;
+
+        State(boolean isOpen) {
+            this.isOpen = isOpen;
+        }
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/screen/PanelManager.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/PanelManager.java
@@ -28,6 +28,7 @@ public class PanelManager {
      * List of all open panels from top to bottom.
      */
     private final ObjectList<ModularPanel> panels = ObjectList.create();
+    // a clone of the list to avoid CMEs
     private final List<ModularPanel> panelsClone = new ArrayList<>();
     private final List<ModularPanel> panelsView = Collections.unmodifiableList(this.panelsClone);
     private final ReverseIterable<ModularPanel> reversePanels = new ReverseIterable<>(this.panelsView);
@@ -99,8 +100,15 @@ public class PanelManager {
         return this.mainPanel;
     }
 
+    /**
+     * Returns the panel that was opened last.
+     *
+     * @return last opened panel
+     * @throws IndexOutOfBoundsException if the current state is {@link State#DISPOSED}
+     */
+    @NotNull
     public ModularPanel getTopMostPanel() {
-        return this.panels.peekFirst();
+        return this.panels.getFirst();
     }
 
     @Nullable
@@ -144,22 +152,14 @@ public class PanelManager {
         }
     }
 
-    public void closeTopPanel(boolean alsoCloseMain, boolean animate) {
-        ModularPanel panel = getTopMostPanel();
-        if (panel == getMainPanel() && !alsoCloseMain) return;
-        if (animate) {
-            panel.animateClose();
-            return;
-        }
-        panel.closeIfOpen();
+    public void closeTopPanel(boolean animate) {
+        getTopMostPanel().closeIfOpen(animate);
     }
 
     public void closeAll() {
         for (ModularPanel panel : this.panels) {
             panel.onClose();
         }
-        // this.panels.clear();
-        // this.dirty = true;
         this.state = State.CLOSED;
     }
 

--- a/src/main/java/com/cleanroommc/modularui/screen/viewport/GuiContext.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/viewport/GuiContext.java
@@ -278,7 +278,8 @@ public class GuiContext extends GuiViewportStack {
         return false;
     }
 
-    private void dropDraggable() {
+    @ApiStatus.Internal
+    public void dropDraggable() {
         this.draggable.applyMatrix(this);
         this.draggable.getElement().onDragEnd(this.draggable.getElement().canDropHere(getAbsMouseX(), getAbsMouseY(), this.hovered));
         this.draggable.getElement().setMoving(false);

--- a/src/main/java/com/cleanroommc/modularui/screen/viewport/GuiContext.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/viewport/GuiContext.java
@@ -62,7 +62,7 @@ public class GuiContext extends GuiViewportStack {
 
     public GuiContext(ModularScreen screen) {
         this.screen = screen;
-        this.hoveredWidgets = new HoveredIterable(this.screen.getWindowManager());
+        this.hoveredWidgets = new HoveredIterable(this.screen.getPanelManager());
         this.mc = Minecraft.getMinecraft();
         this.font = this.mc.fontRenderer;
     }
@@ -297,7 +297,7 @@ public class GuiContext extends GuiViewportStack {
                 draggable = new LocatedElement<>((IDraggable) widget, hovered.getTransformationMatrix());
             } else if (widget instanceof ModularPanel) {
                 ModularPanel panel = (ModularPanel) widget;
-                if (panel.isDraggable() && !this.screen.getWindowManager().isAboutToClose(panel)) {
+                if (panel.isDraggable()) {
                     if (!panel.flex().hasFixedSize()) {
                         throw new IllegalStateException("Panel must have a fixed size. It can't specify left AND right or top AND bottom!");
                     }
@@ -347,7 +347,7 @@ public class GuiContext extends GuiViewportStack {
     @ApiStatus.Internal
     public void onFrameUpdate() {
         updateEventState();
-        IGuiElement hovered = this.screen.getWindowManager().getTopWidget();
+        IGuiElement hovered = this.screen.getPanelManager().getTopWidget();
         if (hasDraggable() && (this.lastDragX != this.mouseX || this.lastDragY != this.mouseY)) {
             this.lastDragX = this.mouseX;
             this.lastDragY = this.mouseY;
@@ -465,10 +465,10 @@ public class GuiContext extends GuiViewportStack {
 
     private static class HoveredIterable implements Iterable<IGuiElement> {
 
-        private final WindowManager windowManager;
+        private final PanelManager panelManager;
 
-        private HoveredIterable(WindowManager windowManager) {
-            this.windowManager = windowManager;
+        private HoveredIterable(PanelManager panelManager) {
+            this.panelManager = panelManager;
         }
 
         @NotNull
@@ -476,7 +476,7 @@ public class GuiContext extends GuiViewportStack {
         public Iterator<IGuiElement> iterator() {
             return new Iterator<IGuiElement>() {
 
-                private final Iterator<ModularPanel> panelIt = HoveredIterable.this.windowManager.getOpenPanels().iterator();
+                private final Iterator<ModularPanel> panelIt = HoveredIterable.this.panelManager.getOpenPanels().iterator();
                 private Iterator<LocatedWidget> widgetIt;
 
                 @Override

--- a/src/main/java/com/cleanroommc/modularui/test/TestTile.java
+++ b/src/main/java/com/cleanroommc/modularui/test/TestTile.java
@@ -23,6 +23,7 @@ import com.cleanroommc.modularui.widgets.layout.Column;
 import com.cleanroommc.modularui.widgets.layout.Row;
 import com.cleanroommc.modularui.widgets.textfield.TextFieldWidget;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.init.Items;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
@@ -129,7 +130,8 @@ public class TestTile extends TileEntity implements IGuiHolder<PosGuiData>, ITic
                                                                     .pos(Tooltip.Pos.LEFT);
                                                         })
                                                         .onMousePressed(mouseButton -> {
-                                                            panel.getScreen().openDialog("dialog", this::buildDialog, ModularUI.LOGGER::info);
+                                                            panel.getScreen().close(true);
+                                                            //panel.getScreen().openDialog("dialog", this::buildDialog, ModularUI.LOGGER::info);
                                                             //openSecondWindow(context).openIn(panel.getScreen());
                                                             return true;
                                                         })

--- a/src/main/java/com/cleanroommc/modularui/utils/ObjectList.java
+++ b/src/main/java/com/cleanroommc/modularui/utils/ObjectList.java
@@ -2,6 +2,7 @@ package com.cleanroommc.modularui.utils;
 
 import it.unimi.dsi.fastutil.objects.ObjectCollection;
 import it.unimi.dsi.fastutil.objects.ObjectIterator;
+import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
@@ -49,12 +50,16 @@ public interface ObjectList<V> extends it.unimi.dsi.fastutil.objects.ObjectList<
 
     void addLast(V v);
 
+    @NotNull
     V getFirst();
 
+    @NotNull
     V getLast();
 
+    @NotNull
     V removeFirst();
 
+    @NotNull
     V removeLast();
 
     @Nullable
@@ -71,6 +76,7 @@ public interface ObjectList<V> extends it.unimi.dsi.fastutil.objects.ObjectList<
 
     void trim();
 
+    @NotNull
     V[] elements();
 
     class ObjectArrayList<V> extends it.unimi.dsi.fastutil.objects.ObjectArrayList<V> implements ObjectList<V> {
@@ -121,22 +127,22 @@ public interface ObjectList<V> extends it.unimi.dsi.fastutil.objects.ObjectList<
         }
 
         @Override
-        public V getFirst() {
+        public @NotNull V getFirst() {
             return get(0);
         }
 
         @Override
-        public V getLast() {
+        public @NotNull V getLast() {
             return get(size() - 1);
         }
 
         @Override
-        public V removeFirst() {
+        public @NotNull V removeFirst() {
             return remove(0);
         }
 
         @Override
-        public V removeLast() {
+        public @NotNull V removeLast() {
             return remove(size() - 1);
         }
 

--- a/src/main/java/com/cleanroommc/modularui/value/sync/PanelSyncHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/PanelSyncHandler.java
@@ -42,7 +42,7 @@ public abstract class PanelSyncHandler extends SyncHandler {
 
     public void closePanel() {
         if (getSyncManager().isClient()) {
-            if (this.openedPanel != null) this.openedPanel.animateClose();
+            if (this.openedPanel != null) this.openedPanel.closeIfOpen(true);
         } else {
             syncToClient(2);
         }

--- a/src/main/java/com/cleanroommc/modularui/widgets/ButtonWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/ButtonWidget.java
@@ -29,7 +29,7 @@ public class ButtonWidget<W extends ButtonWidget<W>> extends SingleChildWidget<W
                         if (panelSyncHandler != null) {
                             panelSyncHandler.closePanel();
                         } else {
-                            buttonWidget.getPanel().animateClose();
+                            buttonWidget.getPanel().closeIfOpen(true);
                         }
                         return true;
                     }

--- a/src/main/java/com/cleanroommc/modularui/widgets/ColorPickerDialog.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/ColorPickerDialog.java
@@ -34,7 +34,7 @@ public class ColorPickerDialog extends Dialog<Integer> {
     private final Rectangle sliderBackgroundV = new Rectangle();
 
     public ColorPickerDialog(Consumer<Integer> resultConsumer, int startColor, boolean controlAlpha) {
-        this("color_picker", resultConsumer, startColor, false);
+        this("color_picker", resultConsumer, startColor, controlAlpha);
     }
 
     public ColorPickerDialog(String name, Consumer<Integer> resultConsumer, int startColor, boolean controlAlpha) {
@@ -143,27 +143,13 @@ public class ColorPickerDialog extends Dialog<Integer> {
                         .child(IKey.str("H: ").asWidget().heightRel(1f))
                         .child(createSlider(new HueBar(GuiAxis.X))
                                 .bounds(0, 360)
-                                .value(new DoubleValue.Dynamic(() -> {
-                                    float h = Color.getHue(this.color);
-                                    return h;
-                                }, val -> {
-                                    float h = (float) val;
-                                    int c = Color.withHSVHue(this.color, h);
-                                    updateColor(c);
-                                }))))
+                                .value(new DoubleValue.Dynamic(() -> Color.getHue(this.color), val -> updateColor(Color.withHSVHue(this.color, (float) val))))))
                 .child(new Row()
                         .widthRel(1f).height(12)
                         .child(IKey.str("S: ").asWidget().heightRel(1f))
                         .child(createSlider(this.sliderBackgroundS)
                                 .bounds(0, 1)
-                                .value(new DoubleValue.Dynamic(() -> {
-                                    float s = Color.getHSVSaturation(this.color);
-                                    return s;
-                                }, val -> {
-                                    float s = (float) val;
-                                    int c = Color.withHSVSaturation(this.color, s);
-                                    updateColor(c);
-                                }))))
+                                .value(new DoubleValue.Dynamic(() -> Color.getHSVSaturation(this.color), val -> updateColor(Color.withHSVSaturation(this.color, (float) val))))))
                 .child(new Row()
                         .widthRel(1f).height(12)
                         .child(IKey.str("V: ").asWidget().heightRel(1f))


### PR DESCRIPTION
- Panel opening and closing no longer need to be queued for next Tick.
- `doSafe()` in `ModularPanel` and `PanelWrapper` was added to execute functions that can close the panel or screen when it shouldnt. This removes the need for scheduling screen opening/closing for next tick.
- renamed `WindowManager` to `PanelManager` (addons shouldnt use this class)
- closed panels and screen can be recovered without rebuilding the ui
- disposed panels and screens can be reopened, but need to be rebuild
- opening a screen while a mui gui is open will only close the mui gui and not dispose it
- once all uis are closed the last mui gui will be disposed
- implements #45 