### PR TITLE
Drawable changes

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/api/drawable/IDrawable.java
+++ b/src/main/java/com/cleanroommc/modularui/api/drawable/IDrawable.java
@@ -3,6 +3,7 @@ package com.cleanroommc.modularui.api.drawable;
 import com.cleanroommc.modularui.api.ITheme;
 import com.cleanroommc.modularui.drawable.Icon;
 import com.cleanroommc.modularui.screen.viewport.GuiContext;
+import com.cleanroommc.modularui.theme.ThemeAPI;
 import com.cleanroommc.modularui.theme.WidgetTheme;
 import com.cleanroommc.modularui.utils.Color;
 import com.cleanroommc.modularui.widget.Widget;
@@ -12,6 +13,7 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 import com.google.gson.JsonObject;
+import org.jetbrains.annotations.ApiStatus;
 
 /**
  * An object which can be drawn. This is mainly used for backgrounds and overlays in
@@ -29,18 +31,47 @@ public interface IDrawable {
      * @param height  draw height
      */
     @SideOnly(Side.CLIENT)
+    default void draw(GuiContext context, int x, int y, int width, int height, WidgetTheme widgetTheme) {
+        applyThemeColor(context.getTheme(), widgetTheme);
+        draw(context, x, y, width, height);
+    }
+
+    /**
+     * @deprecated use {@link #draw(GuiContext, int, int, int, int, WidgetTheme)}
+     */
+    @SideOnly(Side.CLIENT)
+    @Deprecated
     void draw(GuiContext context, int x, int y, int width, int height);
+
+    /**
+     * @deprecated use {@link #drawAtZero(GuiContext, int, int, WidgetTheme)}
+     */
+    @SideOnly(Side.CLIENT)
+    @Deprecated
+    default void drawAtZero(GuiContext context, int width, int height) {
+        drawAtZero(context, width, height, ThemeAPI.DEFAULT_DEFAULT.getFallback());
+    }
 
     /**
      * Draws this drawable at the current (0|0) with the given size.
      *
-     * @param context gui context
-     * @param width   draw width
-     * @param height  draw height
+     * @param context     gui context
+     * @param width       draw width
+     * @param height      draw height
+     * @param widgetTheme
      */
     @SideOnly(Side.CLIENT)
-    default void drawAtZero(GuiContext context, int width, int height) {
-        draw(context, 0, 0, width, height);
+    default void drawAtZero(GuiContext context, int width, int height, WidgetTheme widgetTheme) {
+        draw(context, 0, 0, width, height, widgetTheme);
+    }
+
+    /**
+     * @deprecated use {@link #draw(GuiContext, Area, WidgetTheme)}
+     */
+    @SideOnly(Side.CLIENT)
+    @Deprecated
+    default void draw(GuiContext context, Area area) {
+        draw(context, area.x, area.y, area.width, area.height, ThemeAPI.DEFAULT_DEFAULT.getFallback());
     }
 
     /**
@@ -50,8 +81,17 @@ public interface IDrawable {
      * @param area    draw area
      */
     @SideOnly(Side.CLIENT)
-    default void draw(GuiContext context, Area area) {
-        draw(context, area.x, area.y, area.width, area.height);
+    default void draw(GuiContext context, Area area, WidgetTheme widgetTheme) {
+        draw(context, area.x, area.y, area.width, area.height, widgetTheme);
+    }
+
+    /**
+     * @deprecated use {@link #drawAtZero(GuiContext, Area, WidgetTheme)}
+     */
+    @Deprecated
+    @SideOnly(Side.CLIENT)
+    default void drawAtZero(GuiContext context, Area area) {
+        draw(context, 0, 0, area.width, area.height, ThemeAPI.DEFAULT_DEFAULT.getFallback());
     }
 
     /**
@@ -61,8 +101,8 @@ public interface IDrawable {
      * @param area    draw area
      */
     @SideOnly(Side.CLIENT)
-    default void drawAtZero(GuiContext context, Area area) {
-        draw(context, 0, 0, area.width, area.height);
+    default void drawAtZero(GuiContext context, Area area, WidgetTheme widgetTheme) {
+        draw(context, 0, 0, area.width, area.height, widgetTheme);
     }
 
     /**
@@ -71,6 +111,8 @@ public interface IDrawable {
      * @param theme       theme to apply color of
      * @param widgetTheme widget theme to apply color of
      */
+    @Deprecated
+    @ApiStatus.ScheduledForRemoval(inVersion = "2.6.0")
     default void applyThemeColor(ITheme theme, WidgetTheme widgetTheme) {
         Color.setGlColorOpaque(Color.WHITE.main);
     }

--- a/src/main/java/com/cleanroommc/modularui/api/drawable/IDrawable.java
+++ b/src/main/java/com/cleanroommc/modularui/api/drawable/IDrawable.java
@@ -31,17 +31,16 @@ public interface IDrawable {
      * @param height  draw height
      */
     @SideOnly(Side.CLIENT)
-    default void draw(GuiContext context, int x, int y, int width, int height, WidgetTheme widgetTheme) {
-        applyThemeColor(context.getTheme(), widgetTheme);
-        draw(context, x, y, width, height);
-    }
+    void draw(GuiContext context, int x, int y, int width, int height, WidgetTheme widgetTheme);
 
     /**
      * @deprecated use {@link #draw(GuiContext, int, int, int, int, WidgetTheme)}
      */
     @SideOnly(Side.CLIENT)
     @Deprecated
-    void draw(GuiContext context, int x, int y, int width, int height);
+    default void draw(GuiContext context, int x, int y, int width, int height) {
+        draw(context, x, y, width, height, WidgetTheme.getDefault());
+    }
 
     /**
      * @deprecated use {@link #drawAtZero(GuiContext, int, int, WidgetTheme)}
@@ -49,7 +48,7 @@ public interface IDrawable {
     @SideOnly(Side.CLIENT)
     @Deprecated
     default void drawAtZero(GuiContext context, int width, int height) {
-        drawAtZero(context, width, height, ThemeAPI.DEFAULT_DEFAULT.getFallback());
+        drawAtZero(context, width, height, WidgetTheme.getDefault());
     }
 
     /**
@@ -71,7 +70,7 @@ public interface IDrawable {
     @SideOnly(Side.CLIENT)
     @Deprecated
     default void draw(GuiContext context, Area area) {
-        draw(context, area.x, area.y, area.width, area.height, ThemeAPI.DEFAULT_DEFAULT.getFallback());
+        draw(context, area.x, area.y, area.width, area.height, WidgetTheme.getDefault());
     }
 
     /**
@@ -91,7 +90,7 @@ public interface IDrawable {
     @Deprecated
     @SideOnly(Side.CLIENT)
     default void drawAtZero(GuiContext context, Area area) {
-        draw(context, 0, 0, area.width, area.height, ThemeAPI.DEFAULT_DEFAULT.getFallback());
+        draw(context, 0, 0, area.width, area.height, WidgetTheme.getDefault());
     }
 
     /**
@@ -148,12 +147,12 @@ public interface IDrawable {
     /**
      * An empty drawable. Does nothing.
      */
-    IDrawable EMPTY = (context, x, y, width, height) -> {};
+    IDrawable EMPTY = (context, x, y, width, height, widgetTheme) -> {};
 
     /**
      * An empty drawable used to mark hover textures as "should not be used"!
      */
-    IDrawable NONE = (context, x, y, width, height) -> {};
+    IDrawable NONE = (context, x, y, width, height, widgetTheme) -> {};
 
     /**
      * A widget wrapping a drawable. The drawable is drawn between the background and the overlay.

--- a/src/main/java/com/cleanroommc/modularui/api/drawable/IKey.java
+++ b/src/main/java/com/cleanroommc/modularui/api/drawable/IKey.java
@@ -1,6 +1,5 @@
 package com.cleanroommc.modularui.api.drawable;
 
-import com.cleanroommc.modularui.api.ITheme;
 import com.cleanroommc.modularui.drawable.AnimatedText;
 import com.cleanroommc.modularui.drawable.StyledText;
 import com.cleanroommc.modularui.drawable.TextRenderer;
@@ -104,17 +103,13 @@ public interface IKey extends IDrawable {
 
     @SideOnly(Side.CLIENT)
     @Override
-    default void draw(GuiContext context, int x, int y, int width, int height) {
+    default void draw(GuiContext context, int x, int y, int width, int height, WidgetTheme widgetTheme) {
+        renderer.setColor(widgetTheme.getTextColor());
+        renderer.setShadow(widgetTheme.getTextShadow());
         renderer.setAlignment(Alignment.Center, width, height);
         renderer.setScale(1f);
         renderer.setPos(x, y);
         renderer.draw(get());
-    }
-
-    @Override
-    default void applyThemeColor(ITheme theme, WidgetTheme widgetTheme) {
-        renderer.setColor(widgetTheme.getTextColor());
-        renderer.setShadow(widgetTheme.getTextShadow());
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/modularui/api/widget/IGuiElement.java
+++ b/src/main/java/com/cleanroommc/modularui/api/widget/IGuiElement.java
@@ -1,6 +1,5 @@
 package com.cleanroommc.modularui.api.widget;
 
-import com.cleanroommc.modularui.api.ITheme;
 import com.cleanroommc.modularui.api.layout.IResizeable;
 import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.screen.ModularScreen;
@@ -44,14 +43,6 @@ public interface IGuiElement {
     default Area getParentArea() {
         return getParent().getArea();
     }
-
-    /**
-     * Applies default backgrounds and colors if they haven't been set already.
-     *
-     * @param theme themes to apply
-     */
-    default void applyTheme(ITheme theme) {}
-
 
     /**
      * Draws this element

--- a/src/main/java/com/cleanroommc/modularui/drawable/AnimatedText.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/AnimatedText.java
@@ -2,6 +2,7 @@ package com.cleanroommc.modularui.drawable;
 
 import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.screen.viewport.GuiContext;
+import com.cleanroommc.modularui.theme.WidgetTheme;
 import com.cleanroommc.modularui.utils.Alignment;
 
 import net.minecraft.client.Minecraft;
@@ -67,7 +68,7 @@ public class AnimatedText extends StyledText {
 
     @SideOnly(Side.CLIENT)
     @Override
-    public void draw(GuiContext context, int x, int y, int width, int height) {
+    public void draw(GuiContext context, int x, int y, int width, int height, WidgetTheme widgetTheme) {
         if (this.fullString == null || !this.fullString.equals(super.get())) {
             if (this.isAnimating) {
                 this.fullString = super.get();
@@ -80,7 +81,7 @@ public class AnimatedText extends StyledText {
         }
         advance();
         if (this.currentString.isEmpty()) return;
-        super.draw(context, x, y, width, height);
+        super.draw(context, x, y, width, height, widgetTheme);
     }
 
     public AnimatedText startAnimation() {

--- a/src/main/java/com/cleanroommc/modularui/drawable/Circle.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/Circle.java
@@ -2,6 +2,7 @@ package com.cleanroommc.modularui.drawable;
 
 import com.cleanroommc.modularui.api.drawable.IDrawable;
 import com.cleanroommc.modularui.screen.viewport.GuiContext;
+import com.cleanroommc.modularui.theme.WidgetTheme;
 import com.cleanroommc.modularui.utils.Color;
 import com.cleanroommc.modularui.utils.JsonHelper;
 
@@ -45,7 +46,7 @@ public class Circle implements IDrawable {
 
     @SideOnly(Side.CLIENT)
     @Override
-    public void draw(GuiContext context, int x0, int y0, int width, int height) {
+    public void draw(GuiContext context, int x0, int y0, int width, int height, WidgetTheme widgetTheme) {
         GuiDraw.drawEllipse(x0, y0, width, height, this.colorInner, this.colorOuter, this.segments);
     }
 

--- a/src/main/java/com/cleanroommc/modularui/drawable/DrawableArray.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/DrawableArray.java
@@ -26,11 +26,6 @@ public class DrawableArray implements IDrawable {
     }
 
     @Override
-    public void draw(GuiContext context, int x, int y, int width, int height) {
-        draw(context, x, y, width, height, WidgetTheme.getDefault());
-    }
-
-    @Override
     public boolean canApplyTheme() {
         for (IDrawable drawable : this.drawables) {
             if (drawable.canApplyTheme()) {

--- a/src/main/java/com/cleanroommc/modularui/drawable/DrawableArray.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/DrawableArray.java
@@ -1,6 +1,5 @@
 package com.cleanroommc.modularui.drawable;
 
-import com.cleanroommc.modularui.api.ITheme;
 import com.cleanroommc.modularui.api.drawable.IDrawable;
 import com.cleanroommc.modularui.screen.viewport.GuiContext;
 import com.cleanroommc.modularui.theme.WidgetTheme;
@@ -13,7 +12,6 @@ public class DrawableArray implements IDrawable {
     public static final IDrawable[] EMPTY_BACKGROUND = {};
 
     private final IDrawable[] drawables;
-    private WidgetTheme currentWidgetTheme;
 
     public DrawableArray(IDrawable... drawables) {
         this.drawables = drawables == null || drawables.length == 0 ? EMPTY_BACKGROUND : drawables;
@@ -21,19 +19,15 @@ public class DrawableArray implements IDrawable {
 
     @SideOnly(Side.CLIENT)
     @Override
-    public void draw(GuiContext context, int x, int y, int width, int height) {
+    public void draw(GuiContext context, int x, int y, int width, int height, WidgetTheme widgetTheme) {
         for (IDrawable drawable : this.drawables) {
-            if (this.currentWidgetTheme != null) {
-                drawable.applyThemeColor(context.getTheme(), this.currentWidgetTheme);
-            }
-            drawable.draw(context, x, y, width, height);
+            drawable.draw(context, x, y, width, height, widgetTheme);
         }
-        this.currentWidgetTheme = null;
     }
 
     @Override
-    public void applyThemeColor(ITheme theme, WidgetTheme widgetTheme) {
-        this.currentWidgetTheme = widgetTheme;
+    public void draw(GuiContext context, int x, int y, int width, int height) {
+        draw(context, x, y, width, height, WidgetTheme.getDefault());
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/modularui/drawable/DynamicDrawable.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/DynamicDrawable.java
@@ -25,21 +25,16 @@ public class DynamicDrawable implements IDrawable {
 
     @SideOnly(Side.CLIENT)
     @Override
-    public void draw(GuiContext context, int x, int y, int width, int height) {
+    public void draw(GuiContext context, int x, int y, int width, int height, WidgetTheme widgetTheme) {
         IDrawable drawable = this.supplier.get();
         if (drawable != null) {
-            drawable.draw(context, x, y, width, height);
+            drawable.draw(context, x, y, width, height, widgetTheme);
         }
     }
 
     @Override
-    public void applyThemeColor(ITheme theme, WidgetTheme widgetTheme) {
-        IDrawable drawable = this.supplier.get();
-        if (drawable != null) {
-            drawable.applyThemeColor(theme, widgetTheme);
-        } else {
-            IDrawable.super.applyThemeColor(theme, widgetTheme);
-        }
+    public void draw(GuiContext context, int x, int y, int width, int height) {
+
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/modularui/drawable/DynamicDrawable.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/DynamicDrawable.java
@@ -33,11 +33,6 @@ public class DynamicDrawable implements IDrawable {
     }
 
     @Override
-    public void draw(GuiContext context, int x, int y, int width, int height) {
-
-    }
-
-    @Override
     public boolean canApplyTheme() {
         IDrawable drawable = this.supplier.get();
         if (drawable != null) {

--- a/src/main/java/com/cleanroommc/modularui/drawable/GuiDraw.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/GuiDraw.java
@@ -5,9 +5,7 @@ import com.cleanroommc.modularui.utils.Color;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.gui.Gui;
-import net.minecraft.client.renderer.BufferBuilder;
-import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.*;
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
@@ -336,6 +334,22 @@ public class GuiDraw {
         }
 
         tessellator.draw();
+    }
+
+    public static void drawItem(ItemStack item, int x, int y, float width, float height) {
+        if (item.isEmpty()) return;
+        GlStateManager.pushMatrix();
+        RenderHelper.enableGUIStandardItemLighting();
+        GlStateManager.enableDepth();
+        GlStateManager.scale(width / 16f, height / 16f, 1);
+        RenderItem renderItem = Minecraft.getMinecraft().getRenderItem();
+        renderItem.zLevel = 200;
+        renderItem.renderItemAndEffectIntoGUI(Minecraft.getMinecraft().player, item, x, y);
+        renderItem.zLevel = 0;
+        GlStateManager.disableDepth();
+        RenderHelper.enableStandardItemLighting();
+        GlStateManager.disableLighting();
+        GlStateManager.popMatrix();
     }
 
     public static void drawFluidTexture(FluidStack content, float x0, float y0, float width, float height, float z) {

--- a/src/main/java/com/cleanroommc/modularui/drawable/HueBar.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/HueBar.java
@@ -3,6 +3,7 @@ package com.cleanroommc.modularui.drawable;
 import com.cleanroommc.modularui.api.GuiAxis;
 import com.cleanroommc.modularui.api.drawable.IDrawable;
 import com.cleanroommc.modularui.screen.viewport.GuiContext;
+import com.cleanroommc.modularui.theme.WidgetTheme;
 import com.cleanroommc.modularui.utils.Color;
 
 public class HueBar implements IDrawable {
@@ -23,7 +24,7 @@ public class HueBar implements IDrawable {
     }
 
     @Override
-    public void draw(GuiContext context, int x, int y, int width, int height) {
+    public void draw(GuiContext context, int x, int y, int width, int height, WidgetTheme widgetTheme) {
         int size = this.axis.isHorizontal() ? width : height;
         float step = size / 6f;
         int previous = COLORS[5];

--- a/src/main/java/com/cleanroommc/modularui/drawable/Icon.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/Icon.java
@@ -3,6 +3,7 @@ package com.cleanroommc.modularui.drawable;
 import com.cleanroommc.modularui.api.drawable.IDrawable;
 import com.cleanroommc.modularui.api.drawable.IIcon;
 import com.cleanroommc.modularui.screen.viewport.GuiContext;
+import com.cleanroommc.modularui.theme.WidgetTheme;
 import com.cleanroommc.modularui.utils.Alignment;
 import com.cleanroommc.modularui.utils.JsonHelper;
 import com.cleanroommc.modularui.widget.sizer.Box;
@@ -43,7 +44,7 @@ public class Icon implements IIcon {
 
     @SideOnly(Side.CLIENT)
     @Override
-    public void draw(GuiContext context, int x, int y, int width, int height) {
+    public void draw(GuiContext context, int x, int y, int width, int height, WidgetTheme widgetTheme) {
         x += this.margin.left;
         y += this.margin.top;
         width -= this.margin.horizontal();
@@ -56,7 +57,7 @@ public class Icon implements IIcon {
             y += (int) (height * this.alignment.y - this.height * this.alignment.y);
             height = this.height;
         }
-        this.drawable.draw(context, x, y, width, height);
+        this.drawable.draw(context, x, y, width, height, widgetTheme);
     }
 
     public Alignment getAlignment() {

--- a/src/main/java/com/cleanroommc/modularui/drawable/IconRenderer.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/IconRenderer.java
@@ -24,7 +24,7 @@ public class IconRenderer {
     protected Alignment alignment = Alignment.TopLeft;
     protected float scale = 1f;
     protected boolean shadow = false;
-    protected int color = 0;//Theme.INSTANCE.getText();
+    protected int color = 0;
     protected int linePadding = 1;
     protected boolean simulate;
     protected float lastWidth = 0, lastHeight = 0;

--- a/src/main/java/com/cleanroommc/modularui/drawable/IngredientDrawable.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/IngredientDrawable.java
@@ -2,13 +2,9 @@ package com.cleanroommc.modularui.drawable;
 
 import com.cleanroommc.modularui.api.drawable.IDrawable;
 import com.cleanroommc.modularui.screen.viewport.GuiContext;
-
 import com.cleanroommc.modularui.theme.WidgetTheme;
 
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.RenderHelper;
-import net.minecraft.client.renderer.RenderItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.Ingredient;
 import net.minecraftforge.fml.relauncher.Side;
@@ -31,19 +27,9 @@ public class IngredientDrawable implements IDrawable {
     public void draw(GuiContext context, int x, int y, int width, int height, WidgetTheme widgetTheme) {
         if (this.items.length == 0) return;
         ItemStack item = this.items[(int) (Minecraft.getSystemTime() % (1000 * this.items.length)) / 1000];
-        if (item.isEmpty()) return;
-        GlStateManager.pushMatrix();
-        RenderHelper.enableGUIStandardItemLighting();
-        GlStateManager.enableDepth();
-        GlStateManager.scale(width / 16f, height / 16f, 1);
-        RenderItem renderItem = Minecraft.getMinecraft().getRenderItem();
-        renderItem.zLevel = 200;
-        renderItem.renderItemAndEffectIntoGUI(Minecraft.getMinecraft().player, item, x, y);
-        renderItem.zLevel = 0;
-        GlStateManager.disableDepth();
-        RenderHelper.enableStandardItemLighting();
-        GlStateManager.disableLighting();
-        GlStateManager.popMatrix();
+        if (item != null) {
+            GuiDraw.drawItem(item, x, y, width, height);
+        }
     }
 
     public ItemStack[] getItems() {

--- a/src/main/java/com/cleanroommc/modularui/drawable/IngredientDrawable.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/IngredientDrawable.java
@@ -3,6 +3,8 @@ package com.cleanroommc.modularui.drawable;
 import com.cleanroommc.modularui.api.drawable.IDrawable;
 import com.cleanroommc.modularui.screen.viewport.GuiContext;
 
+import com.cleanroommc.modularui.theme.WidgetTheme;
+
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.RenderHelper;
@@ -26,7 +28,7 @@ public class IngredientDrawable implements IDrawable {
 
     @SideOnly(Side.CLIENT)
     @Override
-    public void draw(GuiContext context, int x, int y, int width, int height) {
+    public void draw(GuiContext context, int x, int y, int width, int height, WidgetTheme widgetTheme) {
         if (this.items.length == 0) return;
         ItemStack item = this.items[(int) (Minecraft.getSystemTime() % (1000 * this.items.length)) / 1000];
         if (item.isEmpty()) return;

--- a/src/main/java/com/cleanroommc/modularui/drawable/ItemDrawable.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/ItemDrawable.java
@@ -2,6 +2,7 @@ package com.cleanroommc.modularui.drawable;
 
 import com.cleanroommc.modularui.api.drawable.IDrawable;
 import com.cleanroommc.modularui.screen.viewport.GuiContext;
+import com.cleanroommc.modularui.theme.WidgetTheme;
 import com.cleanroommc.modularui.utils.GameObjectHelper;
 import com.cleanroommc.modularui.utils.JsonHelper;
 
@@ -35,7 +36,7 @@ public class ItemDrawable implements IDrawable {
 
     @SideOnly(Side.CLIENT)
     @Override
-    public void draw(GuiContext context, int x, int y, int width, int height) {
+    public void draw(GuiContext context, int x, int y, int width, int height, WidgetTheme widgetTheme) {
         if (this.item.isEmpty()) return;
         GlStateManager.pushMatrix();
         RenderHelper.enableGUIStandardItemLighting();

--- a/src/main/java/com/cleanroommc/modularui/drawable/ItemDrawable.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/ItemDrawable.java
@@ -37,19 +37,7 @@ public class ItemDrawable implements IDrawable {
     @SideOnly(Side.CLIENT)
     @Override
     public void draw(GuiContext context, int x, int y, int width, int height, WidgetTheme widgetTheme) {
-        if (this.item.isEmpty()) return;
-        GlStateManager.pushMatrix();
-        RenderHelper.enableGUIStandardItemLighting();
-        GlStateManager.enableDepth();
-        GlStateManager.scale(width / 16f, height / 16f, 1);
-        RenderItem renderItem = Minecraft.getMinecraft().getRenderItem();
-        renderItem.zLevel = 200;
-        renderItem.renderItemAndEffectIntoGUI(Minecraft.getMinecraft().player, this.item, x, y);
-        renderItem.zLevel = 0;
-        GlStateManager.disableDepth();
-        RenderHelper.enableStandardItemLighting();
-        GlStateManager.disableLighting();
-        GlStateManager.popMatrix();
+        GuiDraw.drawItem(this.item, x, y, width, height);
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/modularui/drawable/Rectangle.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/Rectangle.java
@@ -67,18 +67,14 @@ public class Rectangle implements IDrawable {
         return this;
     }
 
+    @SideOnly(Side.CLIENT)
     @Override
-    public void applyThemeColor(ITheme theme, WidgetTheme widgetTheme) {
+    public void draw(GuiContext context, int x0, int y0, int width, int height, WidgetTheme widgetTheme) {
         if (canApplyTheme()) {
             Color.setGlColor(widgetTheme.getColor());
         } else {
             Color.setGlColorOpaque(Color.WHITE.main);
         }
-    }
-
-    @SideOnly(Side.CLIENT)
-    @Override
-    public void draw(GuiContext context, int x0, int y0, int width, int height) {
         if (this.cornerRadius <= 0) {
             GuiDraw.drawRect(x0, y0, width, height, this.colorTL, this.colorTR, this.colorBL, this.colorBR);
             return;

--- a/src/main/java/com/cleanroommc/modularui/drawable/SpriteDrawable.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/SpriteDrawable.java
@@ -2,6 +2,7 @@ package com.cleanroommc.modularui.drawable;
 
 import com.cleanroommc.modularui.api.drawable.IDrawable;
 import com.cleanroommc.modularui.screen.viewport.GuiContext;
+import com.cleanroommc.modularui.theme.WidgetTheme;
 import com.cleanroommc.modularui.widget.Widget;
 
 import net.minecraft.client.renderer.texture.TextureAtlasSprite;
@@ -15,7 +16,7 @@ public class SpriteDrawable implements IDrawable {
     }
 
     @Override
-    public void draw(GuiContext context, int x, int y, int width, int height) {
+    public void draw(GuiContext context, int x, int y, int width, int height, WidgetTheme widgetTheme) {
         GuiDraw.drawSprite(this.sprite, x, y, width, height);
     }
 

--- a/src/main/java/com/cleanroommc/modularui/drawable/StyledText.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/StyledText.java
@@ -2,6 +2,7 @@ package com.cleanroommc.modularui.drawable;
 
 import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.screen.viewport.GuiContext;
+import com.cleanroommc.modularui.theme.WidgetTheme;
 import com.cleanroommc.modularui.utils.Alignment;
 import com.cleanroommc.modularui.widgets.TextWidget;
 
@@ -29,16 +30,12 @@ public class StyledText implements IKey {
 
     @SideOnly(Side.CLIENT)
     @Override
-    public void draw(GuiContext context, int x, int y, int width, int height) {
+    public void draw(GuiContext context, int x, int y, int width, int height, WidgetTheme widgetTheme) {
         renderer.setAlignment(this.alignment, width, height);
-        if (this.colorChanged) {
-            renderer.setColor(this.color);
-        }
+        renderer.setColor(this.colorChanged ? this.color : widgetTheme.getColor());
         renderer.setScale(this.scale);
         renderer.setPos(x, y);
-        if (this.shadowChanged) {
-            renderer.setShadow(this.shadow);
-        }
+        renderer.setShadow(this.shadowChanged ? this.shadow : widgetTheme.getTextShadow());
         renderer.draw(get());
     }
 

--- a/src/main/java/com/cleanroommc/modularui/drawable/TextIcon.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/TextIcon.java
@@ -2,6 +2,7 @@ package com.cleanroommc.modularui.drawable;
 
 import com.cleanroommc.modularui.api.drawable.IIcon;
 import com.cleanroommc.modularui.screen.viewport.GuiContext;
+import com.cleanroommc.modularui.theme.WidgetTheme;
 import com.cleanroommc.modularui.utils.Alignment;
 import com.cleanroommc.modularui.widget.sizer.Box;
 
@@ -26,7 +27,7 @@ public class TextIcon implements IIcon {
 
     @SideOnly(Side.CLIENT)
     @Override
-    public void draw(GuiContext context, int x, int y, int width, int height) {
+    public void draw(GuiContext context, int x, int y, int width, int height, WidgetTheme widgetTheme) {
         TextRenderer.SHARED.setPos(x, y);
         TextRenderer.SHARED.setAlignment(this.alignment, width);
         TextRenderer.SHARED.setScale(this.scale);

--- a/src/main/java/com/cleanroommc/modularui/drawable/UITexture.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/UITexture.java
@@ -128,7 +128,12 @@ public class UITexture implements IDrawable {
 
     @SideOnly(Side.CLIENT)
     @Override
-    public void draw(GuiContext context, int x, int y, int width, int height) {
+    public void draw(GuiContext context, int x, int y, int width, int height, WidgetTheme widgetTheme) {
+        if (canApplyTheme()) {
+            Color.setGlColor(widgetTheme.getColor());
+        } else {
+            Color.setGlColorOpaque(Color.WHITE.main);
+        }
         draw((float) x, y, width, height);
     }
 
@@ -138,15 +143,6 @@ public class UITexture implements IDrawable {
 
     public void drawSubArea(float x, float y, float width, float height, float uStart, float vStart, float uEnd, float vEnd) {
         GuiDraw.drawTexture(this.location, x, y, x + width, y + height, calcU(uStart), calcV(vStart), calcU(uEnd), calcV(vEnd));
-    }
-
-    @Override
-    public void applyThemeColor(ITheme theme, WidgetTheme widgetTheme) {
-        if (canApplyTheme()) {
-            Color.setGlColor(widgetTheme.getColor());
-        } else {
-            Color.setGlColorOpaque(Color.WHITE.main);
-        }
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/modularui/theme/ThemeAPI.java
+++ b/src/main/java/com/cleanroommc/modularui/theme/ThemeAPI.java
@@ -36,7 +36,8 @@ public class ThemeAPI implements IThemeApi {
         registerWidgetTheme(Theme.ITEM_SLOT, new WidgetSlotTheme(GuiTextures.SLOT_ITEM, Color.withAlpha(Color.WHITE.main, 0x60)), WidgetSlotTheme::new);
         registerWidgetTheme(Theme.FLUID_SLOT, new WidgetSlotTheme(GuiTextures.SLOT_FLUID, Color.withAlpha(Color.WHITE.main, 0x60)), WidgetSlotTheme::new);
         registerWidgetTheme(Theme.TEXT_FIELD, new WidgetTextFieldTheme(0xFF2F72A8), (parent, json, fallback) -> new WidgetTextFieldTheme(parent, fallback, json));
-        registerWidgetTheme(Theme.TOGGLE_BUTTON, new WidgetToggleButtonTheme(GuiTextures.MC_BUTTON, GuiTextures.MC_BUTTON_HOVERED, Color.WHITE.main, Color.WHITE.main, true, GuiTextures.MC_BUTTON_DISABLED, IDrawable.NONE, Color.WHITE.main), WidgetToggleButtonTheme::new);
+        registerWidgetTheme(Theme.TOGGLE_BUTTON, new WidgetToggleButtonTheme(GuiTextures.MC_BUTTON, GuiTextures.MC_BUTTON_HOVERED, Color.WHITE.main, Color.WHITE.main, true,
+                GuiTextures.MC_BUTTON_DISABLED, IDrawable.NONE, Color.WHITE.main, Color.WHITE.main, true), WidgetToggleButtonTheme::new);
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/modularui/theme/WidgetTheme.java
+++ b/src/main/java/com/cleanroommc/modularui/theme/WidgetTheme.java
@@ -8,6 +8,10 @@ import org.jetbrains.annotations.Nullable;
 
 public class WidgetTheme {
 
+    public static WidgetTheme getDefault() {
+        return ThemeAPI.DEFAULT_DEFAULT.getFallback();
+    }
+
     @Nullable
     private final IDrawable background;
     @Nullable

--- a/src/main/java/com/cleanroommc/modularui/theme/WidgetToggleButtonTheme.java
+++ b/src/main/java/com/cleanroommc/modularui/theme/WidgetToggleButtonTheme.java
@@ -8,39 +8,28 @@ import org.jetbrains.annotations.Nullable;
 
 public class WidgetToggleButtonTheme extends WidgetTheme {
 
-    @Nullable
-    private final IDrawable selectedBackground;
-    @Nullable
-    private final IDrawable selectedHoverBackground;
-    private final int selectedColor;
+    private final WidgetTheme selected;
 
     public WidgetToggleButtonTheme(@Nullable IDrawable background, @Nullable IDrawable hoverBackground,
                                    int color, int textColor, boolean textShadow,
                                    @Nullable IDrawable selectedBackground, @Nullable IDrawable selectedHoverBackground,
-                                   int selectedColor) {
+                                   int selectedColor, int selectedTextColor, boolean selectedTextShadow) {
         super(background, hoverBackground, color, textColor, textShadow);
-        this.selectedBackground = selectedBackground;
-        this.selectedHoverBackground = selectedHoverBackground;
-        this.selectedColor = selectedColor;
+        this.selected = new WidgetTheme(selectedBackground, selectedHoverBackground, selectedColor, selectedTextColor, selectedTextShadow);
     }
 
     public WidgetToggleButtonTheme(WidgetTheme parent, JsonObject json, JsonObject fallback) {
         super(parent, json, fallback);
-        WidgetToggleButtonTheme parentToggleButtonTheme = (WidgetToggleButtonTheme) parent;
-        this.selectedBackground = JsonHelper.deserializeWithFallback(json, fallback, IDrawable.class, parentToggleButtonTheme.getSelectedBackground(), "selectedBackground");
-        this.selectedHoverBackground = JsonHelper.deserializeWithFallback(json, fallback, IDrawable.class, parentToggleButtonTheme.getSelectedHoverBackground(), "selectedHoverBackground");
-        this.selectedColor = JsonHelper.getColorWithFallback(json, fallback, parentToggleButtonTheme.getSelectedColor(), "selectedColor");
+        WidgetToggleButtonTheme parentWTBT = (WidgetToggleButtonTheme) parent;
+        IDrawable selectedBackground = JsonHelper.deserializeWithFallback(json, fallback, IDrawable.class, parentWTBT.getSelected().getBackground(), "selectedBackground");
+        IDrawable selectedHoverBackground = JsonHelper.deserializeWithFallback(json, fallback, IDrawable.class, parentWTBT.getSelected().getHoverBackground(), "selectedHoverBackground");
+        int selectedColor = JsonHelper.getColorWithFallback(json, fallback, parentWTBT.getSelected().getColor(), "selectedColor");
+        int selectedTextColor = JsonHelper.getColorWithFallback(json, fallback, parentWTBT.getSelected().getTextColor(), "selectedTextColor");
+        boolean selectedTextShadow = JsonHelper.getBoolWithFallback(json, fallback, parentWTBT.getSelected().getTextShadow(), "selectedTextShadow");
+        this.selected = new WidgetTheme(selectedBackground, selectedHoverBackground, selectedColor, selectedTextColor, selectedTextShadow);
     }
 
-    public @Nullable IDrawable getSelectedBackground() {
-        return this.selectedBackground;
-    }
-
-    public @Nullable IDrawable getSelectedHoverBackground() {
-        return this.selectedHoverBackground;
-    }
-
-    public int getSelectedColor() {
-        return this.selectedColor;
+    public WidgetTheme getSelected() {
+        return selected;
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/widget/Widget.java
+++ b/src/main/java/com/cleanroommc/modularui/widget/Widget.java
@@ -148,8 +148,7 @@ public class Widget<W extends Widget<W>> implements IWidget, IPositioned<W>, ITo
     public void drawBackground(GuiContext context, WidgetTheme widgetTheme) {
         IDrawable bg = getCurrentBackground();
         if (bg != null) {
-            bg.applyThemeColor(context.getTheme(), widgetTheme);
-            bg.drawAtZero(context, getArea());
+            bg.drawAtZero(context, getArea(), widgetTheme);
         }
     }
 
@@ -160,9 +159,8 @@ public class Widget<W extends Widget<W>> implements IWidget, IPositioned<W>, ITo
     public void drawOverlay(GuiContext context, WidgetTheme widgetTheme) {
         IDrawable bg = getCurrentOverlay();
         if (bg != null) {
-            bg.applyThemeColor(context.getTheme(), widgetTheme);
             Box padding = getArea().getPadding();
-            bg.draw(context, padding.left, padding.top, getArea().width - padding.horizontal(), getArea().height - padding.vertical());
+            bg.draw(context, padding.left, padding.top, getArea().width - padding.horizontal(), getArea().height - padding.vertical(), widgetTheme);
         }
     }
 

--- a/src/main/java/com/cleanroommc/modularui/widget/Widget.java
+++ b/src/main/java/com/cleanroommc/modularui/widget/Widget.java
@@ -84,7 +84,6 @@ public class Widget<W extends Widget<W>> implements IWidget, IPositioned<W>, ITo
         if (!getScreen().isClientOnly()) {
             initialiseSyncHandler(getScreen().getSyncManager());
         }
-        applyTheme(this.context.getTheme());
         onInit();
         if (hasChildren()) {
             for (IWidget child : getChildren()) {
@@ -146,7 +145,7 @@ public class Widget<W extends Widget<W>> implements IWidget, IPositioned<W>, ITo
 
     @Override
     public void drawBackground(GuiContext context, WidgetTheme widgetTheme) {
-        IDrawable bg = getCurrentBackground();
+        IDrawable bg = getCurrentBackground(context.getTheme(), widgetTheme);
         if (bg != null) {
             bg.drawAtZero(context, getArea(), widgetTheme);
         }
@@ -157,7 +156,7 @@ public class Widget<W extends Widget<W>> implements IWidget, IPositioned<W>, ITo
 
     @Override
     public void drawOverlay(GuiContext context, WidgetTheme widgetTheme) {
-        IDrawable bg = getCurrentOverlay();
+        IDrawable bg = getCurrentOverlay(context.getTheme(), widgetTheme);
         if (bg != null) {
             Box padding = getArea().getPadding();
             bg.draw(context, padding.left, padding.top, getArea().width - padding.horizontal(), getArea().height - padding.vertical(), widgetTheme);
@@ -169,17 +168,6 @@ public class Widget<W extends Widget<W>> implements IWidget, IPositioned<W>, ITo
         Tooltip tooltip = getTooltip();
         if (tooltip != null && isHoveringFor(tooltip.getShowUpTimer())) {
             tooltip.draw(getContext());
-        }
-    }
-
-    @Override
-    public void applyTheme(ITheme theme) {
-        WidgetTheme widgetTheme = getWidgetTheme(theme);
-        if (this.background == null) {
-            this.background = widgetTheme.getBackground();
-        }
-        if (this.hoverBackground == null) {
-            this.hoverBackground = widgetTheme.getHoverBackground();
         }
     }
 
@@ -199,12 +187,17 @@ public class Widget<W extends Widget<W>> implements IWidget, IPositioned<W>, ITo
         return this.hoverOverlay;
     }
 
-    public IDrawable getCurrentBackground() {
-        IDrawable hoverBackground = getHoverBackground();
-        return hoverBackground != null && hoverBackground != IDrawable.NONE && isHovering() ? hoverBackground : getBackground();
+    public IDrawable getCurrentBackground(ITheme theme, WidgetTheme widgetTheme) {
+        if (isHovering()) {
+            IDrawable hoverBackground = getHoverBackground();
+            if (hoverBackground == null) hoverBackground = widgetTheme.getHoverBackground();
+            if (hoverBackground != null && hoverBackground != IDrawable.NONE) return hoverBackground;
+        }
+        IDrawable background = getBackground();
+        return background == null ? widgetTheme.getBackground() : background;
     }
 
-    public IDrawable getCurrentOverlay() {
+    public IDrawable getCurrentOverlay(ITheme theme, WidgetTheme widgetTheme) {
         IDrawable hoverBackground = getHoverOverlay();
         return hoverBackground != null && hoverBackground != IDrawable.NONE && isHovering() ? hoverBackground : getOverlay();
     }

--- a/src/main/java/com/cleanroommc/modularui/widgets/CategoryList.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/CategoryList.java
@@ -28,9 +28,9 @@ public class CategoryList extends ParentWidget<CategoryList> implements Interact
     public void drawOverlay(GuiContext context, WidgetTheme widgetTheme) {
         super.drawOverlay(context, widgetTheme);
         if (this.expanded) {
-            this.expandedOverlay.drawAtZero(context, getArea());
+            this.expandedOverlay.drawAtZero(context, getArea(), widgetTheme);
         } else {
-            this.collapsedOverlay.drawAtZero(context, getArea());
+            this.collapsedOverlay.drawAtZero(context, getArea(), widgetTheme);
         }
     }
 

--- a/src/main/java/com/cleanroommc/modularui/widgets/CycleButtonWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/CycleButtonWidget.java
@@ -115,8 +115,7 @@ public class CycleButtonWidget extends Widget<CycleButtonWidget> implements Inte
         // make sure texture is up-to-date
         getState();
         // draw state texture after background, but before overlay
-        this.texture.applyThemeColor(context.getTheme(), getWidgetTheme(context.getTheme()));
-        this.texture.draw(context, 0, 0, getArea().w(), getArea().h());
+        this.texture.draw(context, 0, 0, getArea().w(), getArea().h(), widgetTheme);
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/modularui/widgets/PageButton.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/PageButton.java
@@ -31,7 +31,7 @@ public class PageButton extends Widget<PageButton> implements Interactable {
     public void applyTheme(ITheme theme) {
         super.applyTheme(theme);
         if (this.inactiveTexture == null) {
-            this.inactiveTexture = theme.getToggleButtonTheme().getSelectedBackground();
+            this.inactiveTexture = theme.getToggleButtonTheme().getSelected().getBackground();
         }
     }
 

--- a/src/main/java/com/cleanroommc/modularui/widgets/PageButton.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/PageButton.java
@@ -6,6 +6,7 @@ import com.cleanroommc.modularui.api.widget.Interactable;
 import com.cleanroommc.modularui.drawable.DrawableArray;
 import com.cleanroommc.modularui.drawable.TabTexture;
 import com.cleanroommc.modularui.theme.WidgetTheme;
+import com.cleanroommc.modularui.theme.WidgetToggleButtonTheme;
 import com.cleanroommc.modularui.widget.Widget;
 
 import org.jetbrains.annotations.NotNull;
@@ -24,15 +25,8 @@ public class PageButton extends Widget<PageButton> implements Interactable {
 
     @Override
     public WidgetTheme getWidgetTheme(ITheme theme) {
-        return theme.getToggleButtonTheme();
-    }
-
-    @Override
-    public void applyTheme(ITheme theme) {
-        super.applyTheme(theme);
-        if (this.inactiveTexture == null) {
-            this.inactiveTexture = theme.getToggleButtonTheme().getSelected().getBackground();
-        }
+        WidgetToggleButtonTheme widgetTheme = theme.getToggleButtonTheme();
+        return isActive() ? widgetTheme : widgetTheme.getSelected();
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/modularui/widgets/ProgressWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/ProgressWidget.java
@@ -59,8 +59,7 @@ public class ProgressWidget extends Widget<ProgressWidget> {
     @Override
     public void draw(GuiContext context, WidgetTheme widgetTheme) {
         if (this.emptyTexture != null) {
-            this.emptyTexture.applyThemeColor(context.getTheme(), widgetTheme);
-            this.emptyTexture.draw(context, 0, 0, getArea().w(), getArea().h());
+            this.emptyTexture.draw(context, 0, 0, getArea().w(), getArea().h(), widgetTheme);
             Color.setGlColorOpaque(Color.WHITE.main);
         }
         float progress = getCurrentProgress();

--- a/src/main/java/com/cleanroommc/modularui/widgets/SliderWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/SliderWidget.java
@@ -80,11 +80,11 @@ public class SliderWidget extends Widget<SliderWidget> implements Interactable {
                 if (this.axis.isHorizontal()) {
                     pos -= this.stopperWidth / 2;
                     int crossAxisPos = (int) (getArea().height / 2D - this.stopperHeight / 2D);
-                    this.stopperDrawable.draw(context, pos, crossAxisPos, this.stopperWidth, this.stopperHeight);
+                    this.stopperDrawable.draw(context, pos, crossAxisPos, this.stopperWidth, this.stopperHeight, WidgetTheme.getDefault());
                 } else {
                     pos -= this.stopperHeight / 2;
                     int crossAxisPos = (int) (getArea().width / 2D - this.stopperWidth / 2D);
-                    this.stopperDrawable.draw(context, crossAxisPos, pos, this.stopperWidth, this.stopperHeight);
+                    this.stopperDrawable.draw(context, crossAxisPos, pos, this.stopperWidth, this.stopperHeight, WidgetTheme.getDefault());
                 }
             }
         }
@@ -93,10 +93,7 @@ public class SliderWidget extends Widget<SliderWidget> implements Interactable {
     @Override
     public void draw(GuiContext context, WidgetTheme widgetTheme) {
         if (this.handleDrawable != null) {
-            ITheme theme = getContext().getTheme();
-            WidgetTheme buttonTheme = theme.getButtonTheme();
-            this.handleDrawable.applyThemeColor(theme, buttonTheme);
-            this.handleDrawable.draw(context, this.sliderArea);
+            this.handleDrawable.draw(context, this.sliderArea, context.getTheme().getButtonTheme());
         }
     }
 

--- a/src/main/java/com/cleanroommc/modularui/widgets/TextWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/TextWidget.java
@@ -28,23 +28,13 @@ public class TextWidget extends Widget<TextWidget> {
     @Override
     public void draw(GuiContext context, WidgetTheme widgetTheme) {
         TextRenderer renderer = TextRenderer.SHARED;
-        renderer.setColor(this.color);
+        renderer.setColor(this.colorChanged ? this.color : widgetTheme.getTextColor());
         renderer.setAlignment(this.alignment, getArea().w() + 1, getArea().h());
-        renderer.setShadow(this.shadow);
+        renderer.setShadow(this.shadowChanged ? this.shadow : widgetTheme.getTextShadow());
         renderer.setPos(getArea().getPadding().left, getArea().getPadding().top);
         renderer.setScale(this.scale);
         renderer.setSimulate(false);
         renderer.draw(this.key.get());
-    }
-
-    @Override
-    public void applyTheme(ITheme theme) {
-        if (!this.colorChanged) {
-            this.color = getWidgetTheme(theme).getTextColor();
-        }
-        if (!this.shadowChanged) {
-            this.shadow = getWidgetTheme(theme).getTextShadow();
-        }
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/modularui/widgets/ToggleButton.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/ToggleButton.java
@@ -4,13 +4,12 @@ import com.cleanroommc.modularui.api.ITheme;
 import com.cleanroommc.modularui.api.drawable.IDrawable;
 import com.cleanroommc.modularui.api.value.IBoolValue;
 import com.cleanroommc.modularui.api.widget.Interactable;
-import com.cleanroommc.modularui.screen.viewport.GuiContext;
 import com.cleanroommc.modularui.theme.WidgetTheme;
 import com.cleanroommc.modularui.theme.WidgetToggleButtonTheme;
-import com.cleanroommc.modularui.utils.Color;
 import com.cleanroommc.modularui.widget.Widget;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 public class ToggleButton extends Widget<ToggleButton> implements Interactable {
 
@@ -30,40 +29,24 @@ public class ToggleButton extends Widget<ToggleButton> implements Interactable {
 
     @Override
     public WidgetTheme getWidgetTheme(ITheme theme) {
-        return theme.getToggleButtonTheme();
+        WidgetToggleButtonTheme widgetTheme = theme.getToggleButtonTheme();
+        return isValueSelected() ? widgetTheme.getSelected() : widgetTheme;
     }
 
     @Override
-    public void applyTheme(ITheme theme) {
-        super.applyTheme(theme);
-        if (this.selectedBackground == null) {
-            this.selectedBackground = theme.getToggleButtonTheme().getSelected().getBackground();
-        }
-        if (this.selectedHoverBackground == null) {
-            this.selectedHoverBackground = theme.getToggleButtonTheme().getSelected().getHoverBackground();
-        }
-    }
-
-    @Override
-    public IDrawable getCurrentBackground() {
+    public @Nullable IDrawable getBackground() {
         if (isValueSelected()) {
-            return this.selectedHoverBackground != null &&
-                    this.selectedHoverBackground != IDrawable.NONE &&
-                    isHovering() ? this.selectedHoverBackground : this.selectedBackground;
+            return this.selectedBackground;
         }
-        return super.getCurrentBackground();
+        return super.getBackground();
     }
 
     @Override
-    public void drawBackground(GuiContext context, WidgetTheme widgetTheme) {
-        IDrawable bg = getCurrentBackground();
-        if (bg != null) {
-            if (isValueSelected() && widgetTheme instanceof WidgetToggleButtonTheme) {
-                bg.drawAtZero(context, getArea(), ((WidgetToggleButtonTheme) widgetTheme).getSelected());
-            } else {
-                bg.drawAtZero(context, getArea(), widgetTheme);
-            }
+    public @Nullable IDrawable getHoverBackground() {
+        if (isValueSelected()) {
+            return this.selectedHoverBackground;
         }
+        return super.getHoverBackground();
     }
 
     public boolean isValueSelected() {

--- a/src/main/java/com/cleanroommc/modularui/widgets/ToggleButton.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/ToggleButton.java
@@ -37,10 +37,10 @@ public class ToggleButton extends Widget<ToggleButton> implements Interactable {
     public void applyTheme(ITheme theme) {
         super.applyTheme(theme);
         if (this.selectedBackground == null) {
-            this.selectedBackground = theme.getToggleButtonTheme().getSelectedBackground();
+            this.selectedBackground = theme.getToggleButtonTheme().getSelected().getBackground();
         }
         if (this.selectedHoverBackground == null) {
-            this.selectedHoverBackground = theme.getToggleButtonTheme().getSelectedHoverBackground();
+            this.selectedHoverBackground = theme.getToggleButtonTheme().getSelected().getHoverBackground();
         }
     }
 
@@ -58,14 +58,11 @@ public class ToggleButton extends Widget<ToggleButton> implements Interactable {
     public void drawBackground(GuiContext context, WidgetTheme widgetTheme) {
         IDrawable bg = getCurrentBackground();
         if (bg != null) {
-            if (isValueSelected()) {
-                Color.setGlColor(((WidgetToggleButtonTheme) widgetTheme).getSelectedColor());
-            } else if (bg.canApplyTheme()) {
-                bg.applyThemeColor(context.getTheme(), widgetTheme);
+            if (isValueSelected() && widgetTheme instanceof WidgetToggleButtonTheme) {
+                bg.drawAtZero(context, getArea(), ((WidgetToggleButtonTheme) widgetTheme).getSelected());
             } else {
-                Color.setGlColor(Color.WHITE.main);
+                bg.drawAtZero(context, getArea(), widgetTheme);
             }
-            bg.drawAtZero(context, getArea());
         }
     }
 


### PR DESCRIPTION
- deprecate `applyThemeColor` in `IDrawable` and add `WidgetTheme` arg to draw methods
- add overloaded draw methods without `WidgetTheme`  with deprecated annotation
- remove `applyThemeColor()` from `IGuiElement`
- rework `WidgetToggleButtonTheme` to just have a `WidgetTheme` field

This will break addons who implement `IDrawable`.