### PR TITLE
Override `slotClick()` to fix issues with ItemStackItemHandler

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/core/mixin/ContainerAccessor.java
+++ b/src/main/java/com/cleanroommc/modularui/core/mixin/ContainerAccessor.java
@@ -1,0 +1,13 @@
+package com.cleanroommc.modularui.core.mixin;
+
+import net.minecraft.inventory.Container;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(Container.class)
+public interface ContainerAccessor {
+
+    @Accessor
+    int getDragEvent();
+}

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
@@ -211,7 +211,6 @@ public class ModularContainer extends Container implements ISortableContainer {
                     emptySlot.putStack(fromStack.splitStack(fromStack.getCount()));
                 }
                 if (fromStack.getCount() < 1) {
-                    fromSlot.putStack(ItemStack.EMPTY);
                     break;
                 }
             }

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
@@ -205,7 +205,7 @@ public class ModularContainer extends Container implements ISortableContainer {
                     }
                 } else if (clickedSlot.canTakeStack(player)) {
                     if (heldStack.isEmpty() && !slotStack.isEmpty()) {
-                        int toRemove = mouseButton == 0 ? slotStack.getCount() : (slotStack.getCount() + 1) / 2;
+                        int toRemove = mouseButton == LEFT_MOUSE ? slotStack.getCount() : (slotStack.getCount() + 1) / 2;
                         inventoryplayer.setItemStack(slotStack.splitStack(toRemove));
                         clickedSlot.putStack(slotStack);
 

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
@@ -180,12 +180,12 @@ public class ModularContainer extends Container implements ISortableContainer {
                         slot.putStack(stack.copy());
                         return stack;
                     }
-                } else if (ItemHandlerHelper.canItemStacksStack(stack, itemstack)) {
+                } else if (itemstack.isEmpty() || ItemHandlerHelper.canItemStacksStack(stack, itemstack)) {
                     int j = itemstack.getCount() + stack.getCount();
                     int maxSize = Math.min(slot.getSlotStackLimit(), stack.getMaxStackSize());
 
                     if (j <= maxSize) {
-                        stack.setCount(0);
+                        fromSlot.putStack(ItemStack.EMPTY);
                         itemstack.setCount(j);
                         slot.onSlotChanged();
                     } else if (itemstack.getCount() < maxSize) {

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
@@ -180,7 +180,7 @@ public class ModularContainer extends Container implements ISortableContainer {
                         slot.putStack(stack.copy());
                         return stack;
                     }
-                } else if (itemstack.isEmpty() || ItemHandlerHelper.canItemStacksStack(stack, itemstack)) {
+                } else if (ItemHandlerHelper.canItemStacksStack(stack, itemstack)) {
                     int j = itemstack.getCount() + stack.getCount();
                     int maxSize = Math.min(slot.getSlotStackLimit(), stack.getMaxStackSize());
 
@@ -210,6 +210,7 @@ public class ModularContainer extends Container implements ISortableContainer {
                     slot.putStack(stack.splitStack(stack.getCount()));
                 }
                 if (stack.getCount() < 1) {
+                    fromSlot.putStack(ItemStack.EMPTY);
                     break;
                 }
             }

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
@@ -1,6 +1,7 @@
 package com.cleanroommc.modularui.screen;
 
 import com.cleanroommc.modularui.ModularUI;
+import com.cleanroommc.modularui.core.mixin.ContainerAccessor;
 import com.cleanroommc.modularui.network.NetworkUtils;
 import com.cleanroommc.modularui.value.sync.GuiSyncManager;
 import com.cleanroommc.modularui.widgets.slot.ModularSlot;
@@ -62,6 +63,10 @@ public class ModularContainer extends Container implements ISortableContainer {
     @SideOnly(Side.CLIENT)
     public ModularContainer() {
         this.guiSyncManager = null;
+    }
+
+    public ContainerAccessor acc() {
+        return (ContainerAccessor) this;
     }
 
     @Override
@@ -160,9 +165,14 @@ public class ModularContainer extends Container implements ISortableContainer {
         return true;
     }
 
-    public ItemStack slotClick(int slotId, int mouseButton, ClickType clickTypeIn, EntityPlayer player) {
+    @Override
+    public @NotNull ItemStack slotClick(int slotId, int mouseButton, @NotNull ClickType clickTypeIn, EntityPlayer player) {
         ItemStack returnable = ItemStack.EMPTY;
         InventoryPlayer inventoryplayer = player.inventory;
+
+        if (clickTypeIn == ClickType.QUICK_CRAFT || acc().getDragEvent() != 0) {
+            return super.slotClick(slotId, mouseButton, clickTypeIn, player);
+        }
 
         if ((clickTypeIn == ClickType.PICKUP || clickTypeIn == ClickType.QUICK_MOVE) &&
                 (mouseButton == LEFT_MOUSE || mouseButton == RIGHT_MOUSE)) {
@@ -267,7 +277,8 @@ public class ModularContainer extends Container implements ISortableContainer {
             ItemStack stack = slot.getStack();
             if (!stack.isEmpty()) {
                 ItemStack remainder = transferItem(slot, stack.copy());
-                stack.setCount(remainder.getCount());
+                if (remainder.isEmpty()) stack = ItemStack.EMPTY;
+                else stack.setCount(remainder.getCount());
                 slot.putStack(stack);
                 return ItemStack.EMPTY;
             }

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
@@ -50,7 +50,8 @@ public class ModularContainer extends Container implements ISortableContainer {
     private final List<ModularSlot> shiftClickSlots = new ArrayList<>();
 
     private static final int DROP_TO_WORLD = -999;
-    private static final int LEFT_MOUSE_CLICK = 0;
+    private static final int LEFT_MOUSE = 0;
+    private static final int RIGHT_MOUSE = 1;
 
     public ModularContainer(GuiSyncManager guiSyncManager) {
         this.guiSyncManager = Objects.requireNonNull(guiSyncManager);
@@ -159,19 +160,20 @@ public class ModularContainer extends Container implements ISortableContainer {
         return true;
     }
 
-    public ItemStack slotClick(int slotId, int dragType, ClickType clickTypeIn, EntityPlayer player) {
+    public ItemStack slotClick(int slotId, int mouseButton, ClickType clickTypeIn, EntityPlayer player) {
         ItemStack returnable = ItemStack.EMPTY;
         InventoryPlayer inventoryplayer = player.inventory;
 
-        if ((clickTypeIn == ClickType.PICKUP || clickTypeIn == ClickType.QUICK_MOVE) && (dragType == 0 || dragType == 1)) {
+        if ((clickTypeIn == ClickType.PICKUP || clickTypeIn == ClickType.QUICK_MOVE) &&
+                (mouseButton == LEFT_MOUSE || mouseButton == RIGHT_MOUSE)) {
             if (slotId == DROP_TO_WORLD) {
                 if (!inventoryplayer.getItemStack().isEmpty()) {
-                    if (dragType == 0) {
+                    if (mouseButton == LEFT_MOUSE) {
                         player.dropItem(inventoryplayer.getItemStack(), true);
                         inventoryplayer.setItemStack(ItemStack.EMPTY);
                     }
 
-                    if (dragType == 1) {
+                    if (mouseButton == RIGHT_MOUSE) {
                         player.dropItem(inventoryplayer.getItemStack().splitStack(1), true);
                     }
                 }
@@ -193,7 +195,7 @@ public class ModularContainer extends Container implements ISortableContainer {
 
                 if (slotStack.isEmpty()) {
                     if (!heldStack.isEmpty() && clickedSlot.isItemValid(heldStack)) {
-                        int stackCount = dragType == LEFT_MOUSE_CLICK ? heldStack.getCount() : 1;
+                        int stackCount = mouseButton == LEFT_MOUSE ? heldStack.getCount() : 1;
 
                         if (stackCount > clickedSlot.getItemStackLimit(heldStack)) {
                             stackCount = clickedSlot.getItemStackLimit(heldStack);
@@ -203,7 +205,7 @@ public class ModularContainer extends Container implements ISortableContainer {
                     }
                 } else if (clickedSlot.canTakeStack(player)) {
                     if (heldStack.isEmpty() && !slotStack.isEmpty()) {
-                        int toRemove = dragType == 0 ? slotStack.getCount() : (slotStack.getCount() + 1) / 2;
+                        int toRemove = mouseButton == 0 ? slotStack.getCount() : (slotStack.getCount() + 1) / 2;
                         inventoryplayer.setItemStack(slotStack.splitStack(toRemove));
                         clickedSlot.putStack(slotStack);
 
@@ -212,7 +214,7 @@ public class ModularContainer extends Container implements ISortableContainer {
                         if (slotStack.getItem() == heldStack.getItem() &&
                                 slotStack.getMetadata() == heldStack.getMetadata() &&
                                 ItemStack.areItemStackTagsEqual(slotStack, heldStack)) {
-                            int stackCount = dragType == LEFT_MOUSE_CLICK ? heldStack.getCount() : 1;
+                            int stackCount = mouseButton == LEFT_MOUSE ? heldStack.getCount() : 1;
 
                             if (stackCount > clickedSlot.getItemStackLimit(heldStack) - slotStack.getCount()) {
                                 stackCount = clickedSlot.getItemStackLimit(heldStack) - slotStack.getCount();
@@ -255,7 +257,7 @@ public class ModularContainer extends Container implements ISortableContainer {
             return returnable;
         }
 
-        return super.slotClick(slotId, dragType, clickTypeIn, player);
+        return super.slotClick(slotId, mouseButton, clickTypeIn, player);
     }
 
 

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
@@ -232,8 +232,7 @@ public class ModularContainer extends Container implements ISortableContainer {
                             clickedSlot.putStack(heldStack);
                             inventoryplayer.setItemStack(slotStack);
                         }
-                    }
-                    else if (slotStack.getItem() == heldStack.getItem() &&
+                    } else if (slotStack.getItem() == heldStack.getItem() &&
                             heldStack.getMaxStackSize() > 1 &&
                             (!slotStack.getHasSubtypes() || slotStack.getMetadata() == heldStack.getMetadata()) &&
                             ItemStack.areItemStackTagsEqual(slotStack, heldStack) && !slotStack.isEmpty()) {

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
@@ -190,7 +190,7 @@ public class ModularContainer extends Container implements ISortableContainer {
             } else {
                 Slot clickedSlot = getSlot(slotId);
 
-                ItemStack slotStack = clickedSlot.getStack().copy();
+                ItemStack slotStack = clickedSlot.getStack();
                 ItemStack heldStack = inventoryplayer.getItemStack();
 
                 if (slotStack.isEmpty()) {

--- a/src/main/java/com/cleanroommc/modularui/test/TestItem.java
+++ b/src/main/java/com/cleanroommc/modularui/test/TestItem.java
@@ -40,16 +40,15 @@ public class TestItem extends Item implements IGuiHolder<HandGuiData> {
 
         ModularPanel panel = ModularPanel.defaultPanel("knapping_gui");
         panel.child(new Column()
-                //.coverChildren()
-                .padding(7)
+                .paddingTop(7)
                 .child(SlotGroupWidget.playerInventory())
                 .child(SlotGroupWidget.builder()
                         .row("II")
                         .row("II")
-                        .key('I', index -> new ItemSlot().slot(SyncHandlers.phantomItemSlot(itemHandler, index)
+                        .key('I', index -> new ItemSlot().slot(SyncHandlers.itemSlot(itemHandler, index)
                                 .ignoreMaxStackSize(true)
                                 .slotGroup("mixer_items")))
-                        .build()));
+                        .build()).marginTop(8));
 
         return panel;
     }

--- a/src/main/java/com/cleanroommc/modularui/test/TestItem.java
+++ b/src/main/java/com/cleanroommc/modularui/test/TestItem.java
@@ -4,6 +4,7 @@ import com.cleanroommc.modularui.api.IGuiHolder;
 import com.cleanroommc.modularui.factory.HandGuiData;
 import com.cleanroommc.modularui.factory.ItemGuiFactory;
 import com.cleanroommc.modularui.screen.ModularPanel;
+import com.cleanroommc.modularui.utils.ItemCapabilityProvider;
 import com.cleanroommc.modularui.utils.ItemStackItemHandler;
 import com.cleanroommc.modularui.value.sync.GuiSyncManager;
 import com.cleanroommc.modularui.value.sync.SyncHandlers;
@@ -20,6 +21,7 @@ import net.minecraft.util.ActionResult;
 import net.minecraft.util.EnumActionResult;
 import net.minecraft.util.EnumHand;
 import net.minecraft.world.World;
+import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
@@ -65,6 +67,14 @@ public class TestItem extends Item implements IGuiHolder<HandGuiData> {
     @Nullable
     @Override
     public ICapabilityProvider initCapabilities(@NotNull ItemStack stack, @Nullable NBTTagCompound nbt) {
-        return new ItemStackItemHandler(stack, 4);
+        return new ItemCapabilityProvider() {
+            @Override
+            public <T> @Nullable T getCapability(@NotNull Capability<T> capability) {
+                if (capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY) {
+                    return CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(new ItemStackItemHandler(stack, 4));
+                }
+                return null;
+            }
+        };
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/utils/ItemCapabilityProvider.java
+++ b/src/main/java/com/cleanroommc/modularui/utils/ItemCapabilityProvider.java
@@ -1,0 +1,25 @@
+package com.cleanroommc.modularui.utils;
+
+import net.minecraft.util.EnumFacing;
+import net.minecraftforge.common.capabilities.Capability;
+import net.minecraftforge.common.capabilities.ICapabilityProvider;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public interface ItemCapabilityProvider extends ICapabilityProvider {
+
+    @Nullable
+    <T> T getCapability(@NotNull Capability<T> capability);
+
+    @Nullable
+    @Override
+    default <T> T getCapability(@NotNull Capability<T> capability, @Nullable EnumFacing facing) {
+        return getCapability(capability);
+    }
+
+    @Override
+    default boolean hasCapability(@NotNull Capability<?> capability, @Nullable EnumFacing facing) {
+        return getCapability(capability) != null;
+    }
+}

--- a/src/main/java/com/cleanroommc/modularui/utils/ItemStackItemHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/utils/ItemStackItemHandler.java
@@ -46,14 +46,6 @@ public class ItemStackItemHandler extends ItemStackHandler implements ICapabilit
         return nbt.getTagList(KEY_ITEMS, Constants.NBT.TAG_COMPOUND);
     }
 
-    @NotNull
-    @Override
-    public ItemStack extractItem(int slot, int amount, boolean simulate) {
-        var stack = super.extractItem(slot, amount, simulate);
-        onContentsChanged(slot);
-        return stack;
-    }
-
     @Override
     public boolean hasCapability(@NotNull Capability<?> capability, @Nullable EnumFacing facing) {
         return capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY;

--- a/src/main/java/com/cleanroommc/modularui/utils/ItemStackItemHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/utils/ItemStackItemHandler.java
@@ -8,111 +8,26 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.items.CapabilityItemHandler;
-import net.minecraftforge.items.IItemHandlerModifiable;
-import net.minecraftforge.items.ItemHandlerHelper;
+import net.minecraftforge.items.ItemStackHandler;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class ItemStackItemHandler implements IItemHandlerModifiable, ICapabilityProvider {
+public class ItemStackItemHandler extends ItemStackHandler implements ICapabilityProvider {
 
     private static final String KEY_ITEMS = "Items";
 
     private final ItemStack container;
-    private final int slots;
 
     public ItemStackItemHandler(ItemStack container, int slots) {
+        super(slots);
         this.container = container;
-        this.slots = slots;
-    }
-
-    @Override
-    public int getSlots() {
-        return this.slots;
-    }
-
-    @NotNull
-    @Override
-    public ItemStack getStackInSlot(int slot) {
-        validateSlotIndex(slot);
-        NBTTagCompound item = (NBTTagCompound) getItemsNbt().get(slot);
-        return item.isEmpty() ? ItemStack.EMPTY : new ItemStack(item);
-    }
-
-    @Override
-    public void setStackInSlot(int slot, @NotNull ItemStack stack) {
-        validateSlotIndex(slot);
-        NBTTagList list = getItemsNbt();
-        list.set(slot, stack.isEmpty() ? new NBTTagCompound() : stack.serializeNBT());
-    }
-
-    @NotNull
-    @Override
-    public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
-        if (stack.isEmpty()) return ItemStack.EMPTY;
-        ItemStack existing = getStackInSlot(slot);
-
-        int limit = getStackLimit(slot, stack);
-
-        if (!existing.isEmpty()) {
-            if (!ItemHandlerHelper.canItemStacksStack(stack, existing))
-                return stack;
-
-            limit -= existing.getCount();
-        }
-
-        if (limit <= 0) return stack;
-
-        boolean reachedLimit = stack.getCount() > limit;
-
-        if (!simulate) {
-            if (existing.isEmpty()) {
-                setStackInSlot(slot, reachedLimit ? ItemHandlerHelper.copyStackWithSize(stack, limit) : stack);
-            } else {
-                existing.grow(reachedLimit ? limit : stack.getCount());
-            }
-            onContentsChanged(slot);
-        }
-
-        return reachedLimit ? ItemHandlerHelper.copyStackWithSize(stack, stack.getCount() - limit) : ItemStack.EMPTY;
-    }
-
-    @NotNull
-    @Override
-    public ItemStack extractItem(int slot, int amount, boolean simulate) {
-        if (amount == 0) return ItemStack.EMPTY;
-
-        ItemStack existing = getStackInSlot(slot);
-        if (existing.isEmpty()) return ItemStack.EMPTY;
-
-        int toExtract = Math.min(amount, existing.getMaxStackSize());
-
-        if (existing.getCount() <= toExtract) {
-            if (!simulate) {
-                setStackInSlot(slot, ItemStack.EMPTY);
-                onContentsChanged(slot);
-            }
-            return existing;
-        } else {
-            if (!simulate) {
-                setStackInSlot(slot, ItemHandlerHelper.copyStackWithSize(existing, existing.getCount() - toExtract));
-                onContentsChanged(slot);
-            }
-
-            return ItemHandlerHelper.copyStackWithSize(existing, toExtract);
-        }
-    }
-
-    @Override
-    public int getSlotLimit(int slot) {
-        return 64;
-    }
-
-    protected int getStackLimit(int slot, @NotNull ItemStack stack) {
-        return Math.min(getSlotLimit(slot), stack.getMaxStackSize());
     }
 
     protected void onContentsChanged(int slot) {
+        var stack = this.stacks.get(slot);
+        var writeTag = stack.isEmpty() ? new NBTTagCompound() : stack.serializeNBT();
+        getItemsNbt().set(slot, writeTag);
     }
 
     public NBTTagList getItemsNbt() {
@@ -131,10 +46,12 @@ public class ItemStackItemHandler implements IItemHandlerModifiable, ICapability
         return nbt.getTagList(KEY_ITEMS, Constants.NBT.TAG_COMPOUND);
     }
 
-    protected void validateSlotIndex(int slot) {
-        if (slot < 0 || slot >= this.slots) {
-            throw new RuntimeException("Slot " + slot + " not in valid range - [0," + this.slots + ")");
-        }
+    @NotNull
+    @Override
+    public ItemStack extractItem(int slot, int amount, boolean simulate) {
+        var stack = super.extractItem(slot, amount, simulate);
+        onContentsChanged(slot);
+        return stack;
     }
 
     @Override
@@ -145,6 +62,9 @@ public class ItemStackItemHandler implements IItemHandlerModifiable, ICapability
     @Override
     @Nullable
     public <T> T getCapability(@NotNull Capability<T> capability, @Nullable EnumFacing facing) {
+        for (int i = 0; i < this.stacks.size(); i++) {
+            stacks.set(i, new ItemStack(getItemsNbt().getCompoundTagAt(i)));
+        }
         return capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY ? CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(this) : null;
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/utils/ItemStackItemHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/utils/ItemStackItemHandler.java
@@ -3,18 +3,13 @@ package com.cleanroommc.modularui.utils;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
-import net.minecraft.util.EnumFacing;
-import net.minecraftforge.common.capabilities.Capability;
-import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.Constants;
-import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandlerModifiable;
 import net.minecraftforge.items.ItemHandlerHelper;
 
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
-public class ItemStackItemHandler implements IItemHandlerModifiable, ICapabilityProvider {
+public class ItemStackItemHandler implements IItemHandlerModifiable {
 
     private static final String KEY_ITEMS = "Items";
 
@@ -135,16 +130,5 @@ public class ItemStackItemHandler implements IItemHandlerModifiable, ICapability
         if (slot < 0 || slot >= this.slots) {
             throw new RuntimeException("Slot " + slot + " not in valid range - [0," + this.slots + ")");
         }
-    }
-
-    @Override
-    public boolean hasCapability(@NotNull Capability<?> capability, @Nullable EnumFacing facing) {
-        return capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY;
-    }
-
-    @Override
-    @Nullable
-    public <T> T getCapability(@NotNull Capability<T> capability, @Nullable EnumFacing facing) {
-        return capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY ? CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(this) : null;
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/utils/ItemStackItemHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/utils/ItemStackItemHandler.java
@@ -8,26 +8,117 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.capabilities.ICapabilityProvider;
 import net.minecraftforge.common.util.Constants;
 import net.minecraftforge.items.CapabilityItemHandler;
-import net.minecraftforge.items.ItemStackHandler;
+import net.minecraftforge.items.IItemHandlerModifiable;
+import net.minecraftforge.items.ItemHandlerHelper;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-public class ItemStackItemHandler extends ItemStackHandler implements ICapabilityProvider {
+public class ItemStackItemHandler implements IItemHandlerModifiable, ICapabilityProvider {
 
     private static final String KEY_ITEMS = "Items";
 
     private final ItemStack container;
+    private final int slots;
 
     public ItemStackItemHandler(ItemStack container, int slots) {
-        super(slots);
         this.container = container;
+        this.slots = slots;
+    }
+
+    @Override
+    public int getSlots() {
+        return this.slots;
+    }
+
+    @NotNull
+    @Override
+    public ItemStack getStackInSlot(int slot) {
+        validateSlotIndex(slot);
+        NBTTagCompound item = (NBTTagCompound) getItemsNbt().get(slot);
+        return item.isEmpty() ? ItemStack.EMPTY : new ItemStack(item);
+    }
+
+    @Override
+    public void setStackInSlot(int slot, @NotNull ItemStack stack) {
+        validateSlotIndex(slot);
+        NBTTagList list = getItemsNbt();
+        list.set(slot, stack.isEmpty() ? new NBTTagCompound() : stack.serializeNBT());
+    }
+
+    @NotNull
+    @Override
+    public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
+        if (stack.isEmpty()) return ItemStack.EMPTY;
+        ItemStack existing = getStackInSlot(slot);
+
+        int limit = getStackLimit(slot, stack);
+
+        if (!existing.isEmpty()) {
+            if (!ItemHandlerHelper.canItemStacksStack(stack, existing))
+                return stack;
+
+            limit -= existing.getCount();
+        }
+
+        if (limit <= 0) return stack;
+
+        boolean reachedLimit = stack.getCount() > limit;
+
+        if (!simulate) {
+            if (existing.isEmpty()) {
+                setStackInSlot(slot, reachedLimit ? ItemHandlerHelper.copyStackWithSize(stack, limit) : stack);
+            } else {
+                existing.grow(reachedLimit ? limit : stack.getCount());
+            }
+            onContentsChanged(slot);
+        }
+
+        return reachedLimit ? ItemHandlerHelper.copyStackWithSize(stack, stack.getCount() - limit) : ItemStack.EMPTY;
+    }
+
+    @NotNull
+    @Override
+    public ItemStack extractItem(int slot, int amount, boolean simulate) {
+        if (amount == 0) return ItemStack.EMPTY;
+
+        ItemStack existing = getStackInSlot(slot);
+        if (existing.isEmpty()) return ItemStack.EMPTY;
+
+        int toExtract = Math.min(amount, existing.getMaxStackSize());
+
+        if (existing.getCount() <= toExtract) {
+            if (!simulate) {
+                setStackInSlot(slot, ItemStack.EMPTY);
+                onContentsChanged(slot);
+            }
+            return existing;
+        } else {
+            if (!simulate) {
+                setStackInSlot(slot, ItemHandlerHelper.copyStackWithSize(existing, existing.getCount() - toExtract));
+                onContentsChanged(slot);
+            }
+
+            return ItemHandlerHelper.copyStackWithSize(existing, toExtract);
+        }
+    }
+
+    @Override
+    public int getSlotLimit(int slot) {
+        return 64;
+    }
+
+    protected int getStackLimit(int slot, @NotNull ItemStack stack) {
+        return Math.min(getSlotLimit(slot), stack.getMaxStackSize());
     }
 
     protected void onContentsChanged(int slot) {
-        var stack = this.stacks.get(slot);
-        var writeTag = stack.isEmpty() ? new NBTTagCompound() : stack.serializeNBT();
-        getItemsNbt().set(slot, writeTag);
+    }
+
+    protected void validateSlotIndex(int slot) {
+        if (slot < 0 || slot >= this.slots) {
+            throw new RuntimeException("Slot " + slot + " not in valid range - [0," + this.slots + ")");
+        }
     }
 
     public NBTTagList getItemsNbt() {
@@ -54,9 +145,6 @@ public class ItemStackItemHandler extends ItemStackHandler implements ICapabilit
     @Override
     @Nullable
     public <T> T getCapability(@NotNull Capability<T> capability, @Nullable EnumFacing facing) {
-        for (int i = 0; i < this.stacks.size(); i++) {
-            stacks.set(i, new ItemStack(getItemsNbt().getCompoundTagAt(i)));
-        }
         return capability == CapabilityItemHandler.ITEM_HANDLER_CAPABILITY ? CapabilityItemHandler.ITEM_HANDLER_CAPABILITY.cast(this) : null;
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/utils/ItemStackItemHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/utils/ItemStackItemHandler.java
@@ -115,12 +115,6 @@ public class ItemStackItemHandler implements IItemHandlerModifiable, ICapability
     protected void onContentsChanged(int slot) {
     }
 
-    protected void validateSlotIndex(int slot) {
-        if (slot < 0 || slot >= this.slots) {
-            throw new RuntimeException("Slot " + slot + " not in valid range - [0," + this.slots + ")");
-        }
-    }
-
     public NBTTagList getItemsNbt() {
         NBTTagCompound nbt = this.container.getTagCompound();
         if (nbt == null) {
@@ -135,6 +129,12 @@ public class ItemStackItemHandler implements IItemHandlerModifiable, ICapability
             nbt.setTag(KEY_ITEMS, list);
         }
         return nbt.getTagList(KEY_ITEMS, Constants.NBT.TAG_COMPOUND);
+    }
+
+    protected void validateSlotIndex(int slot) {
+        if (slot < 0 || slot >= this.slots) {
+            throw new RuntimeException("Slot " + slot + " not in valid range - [0," + this.slots + ")");
+        }
     }
 
     @Override

--- a/src/main/resources/mixin.modularui.json
+++ b/src/main/resources/mixin.modularui.json
@@ -11,5 +11,6 @@
     "MinecraftMixin"
   ],
   "mixins": [
+    "ContainerAccessor"
   ]
 }


### PR DESCRIPTION
Reworks ~~ItemStackItemHandler~~ `ModuleContainer` to fix a dupe when shift-clicking items.

Adds `putStack()` calls to `ModularContainer::transferItem`, `ModularContainer::transferStackInSlot`, and `ModularContainer::slotClick` so that items are saved to NBT for ItemStackItemHandler.
Rename certain variables to make the purpose of the logic in `ModularContainer::transferItem`clearer

Let me know if this will cause problems with other mods