### PR TITLE
Fix Issues with Opening/Closing new panels with PanelSyncHandler

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/screen/ModularPanel.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularPanel.java
@@ -208,8 +208,19 @@ public class ModularPanel extends ParentWidget<ModularPanel> implements IViewpor
     }
 
     void reopen() {
-        if (this.state != State.CLOSED) throw new IllegalStateException();
+        if (this.state != State.CLOSED) throw new IllegalStateException("Panel '" + getName() + "' must be fully closed to be reopened!");
         this.state = State.OPEN;
+        getArea().z(1);
+        this.scale = 1f;
+        this.alpha = 1f;
+        if (shouldAnimate()) {
+            this.scale = 0.75f;
+            this.alpha = 0f;
+            getAnimator().setEndCallback(value -> {
+                this.scale = 1f;
+                this.alpha = 1f;
+            }).forward();
+        }
     }
 
     @MustBeInvokedByOverriders
@@ -637,6 +648,15 @@ public class ModularPanel extends ParentWidget<ModularPanel> implements IViewpor
     public State getState() {
         return this.state;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof ModularPanel other) {
+            return this.getName().equals(other.getName());
+        }
+        return super.equals(obj);
+    }
+
 
     public enum State {
         /**

--- a/src/main/java/com/cleanroommc/modularui/screen/PanelManager.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/PanelManager.java
@@ -71,12 +71,21 @@ public class PanelManager {
         if (this.panels.contains(panel) || isPanelOpen(panel.getName())) {
             throw new IllegalStateException("Panel " + panel.getName() + " is already open.");
         }
-        this.disposal.remove(panel);
-        panel.setPanelGuiContext(this.screen.getContext());
-        this.panels.addFirst(panel);
+        var toOpen = panel;
+        int i = this.disposal.lastIndexOf(toOpen);
+        if (i != -1) {
+            toOpen = this.disposal.get(i);
+            this.disposal.remove(i);
+            toOpen.setEnabled(true);
+            toOpen.reopen();
+        }
+        this.panels.addFirst(toOpen);
         this.dirty = true;
         panel.getArea().setPanelLayer((byte) this.panels.size());
-        panel.onOpen(this.screen);
+        if (i == -1) {
+            toOpen.setPanelGuiContext(this.screen.getContext());
+            panel.onOpen(this.screen);
+        }
         if (resize) {
             WidgetTree.resize(panel);
         }
@@ -143,7 +152,7 @@ public class PanelManager {
 
     public void closePanel(@NotNull ModularPanel panel) {
         if (!hasOpenPanel(panel)) {
-            throw new IllegalArgumentException("Panel '" + panel.getName() + "' is open in this screen!");
+            throw new IllegalArgumentException("Panel '" + panel.getName() + "' is not open in this screen!");
         }
         if (panel == getMainPanel()) {
             closeAll();
@@ -174,6 +183,7 @@ public class PanelManager {
                 this.disposal.removeFirst().dispose();
             }
             this.disposal.add(panel);
+            panel.setEnabled(false);
         }
     }
 

--- a/src/main/java/com/cleanroommc/modularui/value/sync/ItemSlotSH.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/ItemSlotSH.java
@@ -85,6 +85,8 @@ public class ItemSlotSH extends SyncHandler {
             if (!isPhantom()) return;
             ItemStack stack = buf.readItemStack();
             this.slot.putStack(stack);
+        } else if (id == 6) {
+            getSlot().setEnabled(false);
         }
     }
 

--- a/src/main/java/com/cleanroommc/modularui/widget/ParentWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widget/ParentWidget.java
@@ -97,4 +97,13 @@ public class ParentWidget<W extends ParentWidget<W>> extends Widget<W> {
         if (condition.getAsBoolean()) return child(child.get());
         return getThis();
     }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        super.setEnabled(enabled);
+        WidgetTree.foreachChild(this, w -> {
+            w.setEnabled(enabled);
+            return true;
+        }, false);
+    }
 }

--- a/src/main/java/com/cleanroommc/modularui/widget/WidgetTree.java
+++ b/src/main/java/com/cleanroommc/modularui/widget/WidgetTree.java
@@ -172,7 +172,7 @@ public class WidgetTree {
         // render all children if there are any
         List<IWidget> children = parent.getChildren();
         if (!children.isEmpty()) {
-            children.forEach(widget -> drawTree(widget, context, false));
+            children.forEach(widget -> drawTree(widget, context, ignoreEnabled));
         }
 
         if (viewport != null) {

--- a/src/main/java/com/cleanroommc/modularui/widgets/ItemSlot.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/ItemSlot.java
@@ -283,4 +283,11 @@ public class ItemSlot extends Widget<ItemSlot> implements IVanillaSlot, Interact
     public @Nullable Object getIngredient() {
         return this.syncHandler.getSlot().getStack();
     }
+
+    @Override
+    public void setEnabled(boolean enabled) {
+        this.getSlot().setEnabled(enabled);
+        if (this.isSynced()) this.getSyncHandler().syncToServer(6);
+        super.setEnabled(enabled);
+    }
 }


### PR DESCRIPTION
Fixes #51.

* Sets the enabled state for each child of a parent widget
  * Sync to server as well
* Properly retrieve panels in `disposal` and reopen them correctly
* Fixed WidgetTree not passing in `ignoreEnabled` when drawing child widgets
* Construct the panel in PanelSyncHandler's constructor
  * Compare the constructed panel to the result of `createUI()` 
  * Set the constructed panel to the new panel if they are different
* Add a panelSH to the testitem for testing
* Add `Equals()` implementation for ModularPanel for easier comparasion
  * Could maybe be more rigorous