### PR TITLE
Fix Crash when Clicking on a non-slot with a stack in hand

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
@@ -198,6 +198,7 @@ public class ModularContainer extends Container implements ISortableContainer {
 
                 returnable = this.transferStackInSlot(player, slotId);
             } else {
+                if (slotId < 0) return ItemStack.EMPTY;
                 Slot clickedSlot = getSlot(slotId);
 
                 ItemStack slotStack = clickedSlot.getStack();

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
@@ -189,6 +189,9 @@ public class ModularContainer extends Container implements ISortableContainer {
                 }
                 return inventoryplayer.getItemStack();
             }
+
+            if (slotId < 0) return ItemStack.EMPTY;
+
             if (clickTypeIn == ClickType.QUICK_MOVE) {
                 Slot fromSlot = getSlot(slotId);
 
@@ -198,7 +201,6 @@ public class ModularContainer extends Container implements ISortableContainer {
 
                 returnable = this.transferStackInSlot(player, slotId);
             } else {
-                if (slotId < 0) return ItemStack.EMPTY;
                 Slot clickedSlot = getSlot(slotId);
 
                 ItemStack slotStack = clickedSlot.getStack();


### PR DESCRIPTION
Fixes an issue introduced with #49 

If you have a stack in your hand and you click in the gui but not on a slot, `slotClick()` will be called with a `slotId` of -1, which crashes the game with an ArrayIndexOutOfBounds Exception.

Oops.