### PR TITLE
Tooltip & Hover Fix

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/api/widget/ITooltip.java
+++ b/src/main/java/com/cleanroommc/modularui/api/widget/ITooltip.java
@@ -4,7 +4,6 @@ import com.cleanroommc.modularui.api.drawable.IDrawable;
 import com.cleanroommc.modularui.api.drawable.IKey;
 import com.cleanroommc.modularui.screen.Tooltip;
 import com.cleanroommc.modularui.utils.Alignment;
-import com.cleanroommc.modularui.widget.sizer.Area;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -66,17 +65,6 @@ public interface ITooltip<W extends IWidget> {
      */
     default W tooltipBuilder(Consumer<Tooltip> tooltipBuilder) {
         tooltip().tooltipBuilder(tooltipBuilder);
-        return getThis();
-    }
-
-    /**
-     * Sets an excluded area. The tooltip will always try to avoid the excluded area.
-     *
-     * @param area area to exclude
-     * @return this
-     */
-    default W excludeTooltipArea(Area area) {
-        tooltip().excludeArea(area);
         return getThis();
     }
 

--- a/src/main/java/com/cleanroommc/modularui/screen/viewport/GuiViewportStack.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/viewport/GuiViewportStack.java
@@ -150,9 +150,7 @@ public class GuiViewportStack implements IViewportStack {
     }
 
     public void rotateZ(float angle) {
-        checkViewport();
-        this.top.getMatrix().rotate(angle, vec(0f, 0f, 1f));
-        this.top.markDirty();
+        rotate(angle, 0f, 0f, 1f);
     }
 
     public void scale(float x, float y) {

--- a/src/main/java/com/cleanroommc/modularui/test/EventHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/test/EventHandler.java
@@ -16,7 +16,7 @@ public class EventHandler {
                     .inFrontOf(Minecraft.getMinecraft().player, 5, false)
                     .screenScale(0.5f)
                     .open(new TestGui());*/
-            ClientGUI.open(new TestGui());
+            ClientGUI.open(new ResizerTest());
         }
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/test/ResizerTest.java
+++ b/src/main/java/com/cleanroommc/modularui/test/ResizerTest.java
@@ -1,13 +1,14 @@
 package com.cleanroommc.modularui.test;
 
+import com.cleanroommc.modularui.api.drawable.IKey;
+import com.cleanroommc.modularui.api.layout.IViewportStack;
 import com.cleanroommc.modularui.drawable.GuiTextures;
 import com.cleanroommc.modularui.screen.CustomModularScreen;
 import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.screen.viewport.GuiContext;
-import com.cleanroommc.modularui.utils.Alignment;
-import com.cleanroommc.modularui.widgets.ButtonWidget;
-import com.cleanroommc.modularui.widgets.layout.Column;
-import com.cleanroommc.modularui.widgets.layout.Row;
+import com.cleanroommc.modularui.widget.Widget;
+
+import net.minecraft.client.Minecraft;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -25,7 +26,13 @@ public class ResizerTest extends CustomModularScreen {
                         .align(Alignment.Center));*/
         return ModularPanel.defaultPanel("main")
                 .size(150)
-                .child(new Column()
+                .child(new SpinningWidget()
+                        .size(80, 20)
+                        .center()
+                        .background(GuiTextures.MC_BUTTON)
+                        .overlay(IKey.str("Text"))
+                        .addTooltipLine("Long Tooltip Line"));
+                /*.child(new Column()
                         .alignX(0.5f)
                         .heightRel(1f)
                         .margin(0, 7)
@@ -33,6 +40,18 @@ public class ResizerTest extends CustomModularScreen {
                         .mainAxisAlignment(Alignment.MainAxis.SPACE_BETWEEN)
                         .child(new ButtonWidget<>().width(40))
                         .child(new Row().height(30).widthRel(1f).background(GuiTextures.CHECKBOARD).debugName("row"))
-                        .child(new ButtonWidget<>()));
+                        .child(new ButtonWidget<>()));*/
+    }
+
+    private static class SpinningWidget extends Widget<SpinningWidget> {
+
+        @Override
+        public void transform(IViewportStack stack) {
+            super.transform(stack);
+            stack.translate(getArea().width / 2f, getArea().height / 2f);
+            float p = Minecraft.getSystemTime() % 4000 / 4000f;
+            stack.rotateZ((float) (p * Math.PI * 2));
+            stack.translate(-getArea().width / 2f, -getArea().height / 2f);
+        }
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/test/TestGui.java
+++ b/src/main/java/com/cleanroommc/modularui/test/TestGui.java
@@ -50,6 +50,7 @@ public class TestGui extends CustomModularScreen {
         List<List<AvailableElement>> availableMatrix = Grid.mapToMatrix(2, this.lines, (index, value) -> {
             AvailableElement availableElement = new AvailableElement().overlay(IKey.str(value))
                     .size(60, 14)
+                    .addTooltipLine(value)
                     .onMousePressed(mouseButton1 -> {
                         if (this.availableElements.get(value).available) {
                             ref.get().add(value, -1);
@@ -85,6 +86,7 @@ public class TestGui extends CustomModularScreen {
                 .pos(10, 10).right(10).bottom(10))*/
         SortableListWidget<String, SortableListWidget.Item<String>> sortableListWidget = SortableListWidget.sortableBuilder(this.lines, this.configuredOptions,
                 s -> new SortableListWidget.Item<>(s, new Widget<>()
+                        .addTooltipLine(s)
                         .background(GuiTextures.BUTTON_CLEAN)
                         .overlay(IKey.str(s))
                         .left(0).right(10))

--- a/src/main/java/com/cleanroommc/modularui/widget/ParentWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widget/ParentWidget.java
@@ -3,6 +3,8 @@ package com.cleanroommc.modularui.widget;
 import com.cleanroommc.modularui.api.widget.IWidget;
 import com.cleanroommc.modularui.screen.ModularPanel;
 
+import com.cleanroommc.modularui.theme.WidgetTheme;
+
 import org.jetbrains.annotations.NotNull;
 
 import java.util.ArrayList;
@@ -25,7 +27,13 @@ public class ParentWidget<W extends ParentWidget<W>> extends Widget<W> {
         return getBackground() != null ||
                 getHoverBackground() != null ||
                 getHoverOverlay() != null ||
-                getTooltip() != null;
+                getTooltip() != null ||
+                hasThemeBackground();
+    }
+
+    protected boolean hasThemeBackground() {
+        WidgetTheme widgetTheme = getWidgetTheme(getContext().getTheme());
+        return widgetTheme.getBackground() != null || widgetTheme.getHoverBackground() != null;
     }
 
     public boolean addChild(IWidget child, int index) {

--- a/src/main/java/com/cleanroommc/modularui/widget/Widget.java
+++ b/src/main/java/com/cleanroommc/modularui/widget/Widget.java
@@ -210,7 +210,7 @@ public class Widget<W extends Widget<W>> implements IWidget, IPositioned<W>, ITo
     @Override
     public @NotNull Tooltip tooltip() {
         if (this.tooltip == null) {
-            this.tooltip = new Tooltip().excludeArea(getArea());
+            this.tooltip = new Tooltip(this);
         }
         return this.tooltip;
     }

--- a/src/main/java/com/cleanroommc/modularui/widget/WidgetTree.java
+++ b/src/main/java/com/cleanroommc/modularui/widget/WidgetTree.java
@@ -202,14 +202,24 @@ public class WidgetTree {
     }
 
     public static void drawTreeForeground(IWidget parent, GuiContext context) {
+        IViewport viewport = parent instanceof IViewport viewport1 ? viewport1 : null;
+        context.pushMatrix();
+        parent.transform(context);
+
         GlStateManager.color(1, 1, 1, 1);
         GlStateManager.enableBlend();
         parent.drawForeground(context);
 
         List<IWidget> children = parent.getChildren();
         if (!children.isEmpty()) {
+            if (viewport != null) {
+                context.pushViewport(viewport, parent.getArea());
+                viewport.transformChildren(context);
+            }
             children.forEach(widget -> drawTreeForeground(widget, context));
+            if (viewport != null) context.popViewport(viewport);
         }
+        context.popMatrix();
     }
 
     @ApiStatus.Internal

--- a/src/main/java/com/cleanroommc/modularui/widgets/CycleButtonWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/CycleButtonWidget.java
@@ -182,9 +182,9 @@ public class CycleButtonWidget extends Widget<CycleButtonWidget> implements Inte
 
     public CycleButtonWidget length(int length) {
         this.length = length;
+        // adjust tooltip buffer size
         while (this.stateTooltip.size() < this.length) {
-            Tooltip tooltip = new Tooltip().excludeArea(getArea());
-            this.stateTooltip.add(tooltip);
+            this.stateTooltip.add(new Tooltip(this));
         }
         while (this.stateTooltip.size() > this.length) {
             this.stateTooltip.remove(this.stateTooltip.size() - 1);

--- a/src/main/java/com/cleanroommc/modularui/widgets/ItemSlot.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/ItemSlot.java
@@ -49,7 +49,6 @@ public class ItemSlot extends Widget<ItemSlot> implements IVanillaSlot, Interact
     public ItemSlot() {
         tooltip().setAutoUpdate(true).setHasTitleMargin(true);
         tooltipBuilder(tooltip -> {
-            tooltip.excludeArea(getArea());
             if (!isSynced()) return;
             ItemStack stack = getSlot().getStack();
             if (stack.isEmpty()) return;

--- a/src/main/java/com/cleanroommc/modularui/widgets/ScrollingTextWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/ScrollingTextWidget.java
@@ -19,8 +19,7 @@ public class ScrollingTextWidget extends TextWidget {
     public ScrollingTextWidget(IKey key) {
         super(key);
         tooltipBuilder(tooltip -> {
-            tooltip.excludeArea(getArea())
-                    .showUpTimer(10);
+            tooltip.showUpTimer(10);
             if (this.line.getWidth() > getArea().width) {
                 tooltip.addLine(key);
             }

--- a/src/main/java/com/cleanroommc/modularui/widgets/textfield/TextFieldWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/textfield/TextFieldWidget.java
@@ -47,7 +47,6 @@ public class TextFieldWidget extends BaseTextFieldWidget<TextFieldWidget> {
         }
         setText(this.stringValue.getStringValue());
         if (!hasTooltip()) {
-            tooltip().excludeArea(getArea());
             tooltipBuilder(tooltip -> tooltip.addLine(IKey.str(getText())));
         }
         if (!this.changedMarkedColor) {


### PR DESCRIPTION
Before tooltips ignored the widgets transformations. This caused the tooltip to be offset in scrolling widgets. Now the widgets transormations are applied when drawing widgets in foreground. This also means that you can no longer attach the tooltip to another widget or area `exclusionArea`. The tooltip will now show up around the transformed widget without any transformations applied to it except the true pos and size of the widget.

`canHover()` in `ParentWidget` returns true when it as a background, hover background/overlay or tooltip. But some widgets like panels get their background from the current theme when they dont have any. This caused the widget to not be detected as hovered and instead could hover widgets below that widget. This pr fixes it by checking if the current widget theme has any background.

Closes #54 