### PR TITLE
Fix JEI Compat

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/integration/jei/ModularUIHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/integration/jei/ModularUIHandler.java
@@ -60,7 +60,7 @@ public class ModularUIHandler implements IAdvancedGuiHandler<GuiScreenWrapper>, 
     @Nullable
     @Override
     public IRecipeTransferError transferRecipe(@NotNull ModularContainer container, @NotNull IRecipeLayout recipeLayout, @NotNull EntityPlayer player, boolean maxTransfer, boolean doTransfer) {
-        ModularScreen screen = ModularScreen.getCurrent();
+        ModularScreen screen = container.getScreen();
         if (screen instanceof JeiRecipeTransferHandler recipeTransferHandler) {
             return recipeTransferHandler.transferRecipe(recipeLayout, maxTransfer, !doTransfer);
         }

--- a/src/main/java/com/cleanroommc/modularui/screen/GuiScreenWrapper.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/GuiScreenWrapper.java
@@ -56,6 +56,7 @@ public class GuiScreenWrapper extends GuiContainer {
         super(container);
         this.screen = screen;
         this.screen.construct(this);
+        container.setScreen(this.screen);
     }
 
     @Override

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
@@ -46,6 +46,7 @@ public class ModularContainer extends Container implements ISortableContainer {
     private final List<ModularSlot> slots = new ArrayList<>();
     private final List<ModularSlot> shiftClickSlots = new ArrayList<>();
     private ContainerCustomizer containerCustomizer;
+    private ModularScreen modularScreen = null;
 
     public ModularContainer(EntityPlayer player, PanelSyncManager panelSyncManager, String mainPanelName) {
         this.player = player;
@@ -65,6 +66,15 @@ public class ModularContainer extends Container implements ISortableContainer {
         this.syncManager = null;
         this.containerCustomizer = containerCustomizer != null ? containerCustomizer : new ContainerCustomizer();
         this.containerCustomizer.initialize(this);
+    }
+
+    public void setScreen(ModularScreen screen) {
+        this.modularScreen = screen;
+    }
+
+    @Nullable
+    public ModularScreen getScreen() {
+        return modularScreen;
     }
 
     public ContainerAccessor acc() {

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
@@ -19,7 +19,7 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
-import net.minecraftforge.fml.common.Optional;
+import net.minecraftforge.fml.common.Optional.Interface;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
@@ -30,7 +30,7 @@ import org.jetbrains.annotations.Nullable;
 
 import java.util.*;
 
-@Optional.Interface(modid = ModularUI.BOGO_SORT, iface = "com.cleanroommc.bogosorter.api.ISortableContainer")
+@Interface(modid = ModularUI.BOGO_SORT, iface = "com.cleanroommc.bogosorter.api.ISortableContainer")
 public class ModularContainer extends Container implements ISortableContainer {
 
     public static ModularContainer getCurrent(EntityPlayer player) {
@@ -46,7 +46,8 @@ public class ModularContainer extends Container implements ISortableContainer {
     private final List<ModularSlot> slots = new ArrayList<>();
     private final List<ModularSlot> shiftClickSlots = new ArrayList<>();
     private ContainerCustomizer containerCustomizer;
-    private ModularScreen modularScreen = null;
+
+    private Optional<?> optionalScreen = Optional.empty();
 
     public ModularContainer(EntityPlayer player, PanelSyncManager panelSyncManager, String mainPanelName) {
         this.player = player;
@@ -68,13 +69,15 @@ public class ModularContainer extends Container implements ISortableContainer {
         this.containerCustomizer.initialize(this);
     }
 
+    @SideOnly(Side.CLIENT)
     public void setScreen(ModularScreen screen) {
-        this.modularScreen = screen;
+        this.optionalScreen = Optional.ofNullable(screen);
     }
 
     @Nullable
+    @SideOnly(Side.CLIENT)
     public ModularScreen getScreen() {
-        return modularScreen;
+        return (ModularScreen) optionalScreen.orElse(null);
     }
 
     public ContainerAccessor acc() {


### PR DESCRIPTION
Fixes JEI compat. `ModularScreen.getCurrent()` never returns the correct screen because JEI's screen wrapper is the current screen at the time of calling `transferRecipe()`, so a reference to the `ModularScreen` is stored in the container to be retrieved and checked.