### PR TITLE
Disable test overlay by default

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/ClientProxy.java
+++ b/src/main/java/com/cleanroommc/modularui/ClientProxy.java
@@ -37,8 +37,10 @@ public class ClientProxy extends CommonProxy {
         MinecraftForge.EVENT_BUS.register(OverlayManager.class);
         MinecraftForge.EVENT_BUS.register(KeyBindHandler.class);
 
-        if (ModularUIConfig.enabledTestGuis) {
+        if (ModularUIConfig.enableTestGuis) {
             MinecraftForge.EVENT_BUS.register(EventHandler.class);
+        }
+        if (ModularUIConfig.enableTestOverlays) {
             OverlayTest.init();
         }
 

--- a/src/main/java/com/cleanroommc/modularui/CommonProxy.java
+++ b/src/main/java/com/cleanroommc/modularui/CommonProxy.java
@@ -32,7 +32,7 @@ public class CommonProxy {
         MinecraftForge.EVENT_BUS.register(CommonProxy.class);
         MinecraftForge.EVENT_BUS.register(GuiManager.class);
 
-        if (ModularUIConfig.enabledTestGuis) {
+        if (ModularUIConfig.enableTestGuis) {
             MinecraftForge.EVENT_BUS.register(TestBlock.class);
             TestBlock.preInit();
         }

--- a/src/main/java/com/cleanroommc/modularui/ModularUIConfig.java
+++ b/src/main/java/com/cleanroommc/modularui/ModularUIConfig.java
@@ -30,5 +30,9 @@ public class ModularUIConfig {
 
     @Config.RequiresMcRestart
     @Config.Comment("Enables a test block, test item with a test gui and opening a gui by right clicking a diamond.")
-    public static boolean enabledTestGuis = FMLLaunchHandler.isDeobfuscatedEnvironment();
+    public static boolean enableTestGuis = FMLLaunchHandler.isDeobfuscatedEnvironment();
+
+    @Config.RequiresMcRestart
+    @Config.Comment("Enables a test overlay shown on title screen and watermark shown on every GuiContainer.")
+    public static boolean enableTestOverlays = false;
 }


### PR DESCRIPTION
I really like the feature itself, but seeing them in another repositories is a bit too invasive.
Also fixed possible typo `enabledTestGuis` -> `enableTestGuis` (Let me know if it's intended)