### PR TITLE
Fix dedicated server crash on GUI open

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularContainer.java
@@ -48,7 +48,7 @@ public class ModularContainer extends Container implements ISortableContainer {
     private ContainerCustomizer containerCustomizer;
 
     @SideOnly(Side.CLIENT)
-    private ModularScreen optionalScreen = null;
+    private ModularScreen optionalScreen;
 
     public ModularContainer(EntityPlayer player, PanelSyncManager panelSyncManager, String mainPanelName) {
         this.player = player;


### PR DESCRIPTION
```java
@SideOnly(Side.CLIENT)
private ModularScreen optionalScreen = null;
```
This code gets compiled to:
```java
@SideOnly(Side.CLIENT)
private ModularScreen optionalScreen;

public ModularContainer(...) {
    this.optionalScreen = null;
    ...
}
```
Then Forge transformer strips the field, but not the reference