### PR TITLE
Fix a dupe bug with phantom slots

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/screen/ContainerCustomizer.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ContainerCustomizer.java
@@ -175,6 +175,13 @@ public class ContainerCustomizer {
 
             container.detectAndSendChanges();
             return returnable;
+        } else if (clickTypeIn == ClickType.SWAP && mouseButton >= 0 && mouseButton < 9) {
+            final ModularSlot phantom = container.getModularSlot(slotId);
+            ItemStack hotbarStack = inventoryplayer.getStackInSlot(mouseButton).copy();
+            if (phantom.isPhantom()) {
+                phantom.putStack(hotbarStack);
+                return ItemStack.EMPTY;
+            }
         }
 
         return container.superSlotClick(slotId, mouseButton, clickTypeIn, player);

--- a/src/main/java/com/cleanroommc/modularui/test/TestTile.java
+++ b/src/main/java/com/cleanroommc/modularui/test/TestTile.java
@@ -61,6 +61,7 @@ public class TestTile extends TileEntity implements IGuiHolder<PosGuiData>, ITic
             return slot == 0 ? Integer.MAX_VALUE : 64;
         }
     };
+    private final IItemHandlerModifiable phantomInventory = new ItemStackHandler(1);
 
     private final ItemStackHandler bigInventory = new ItemStackHandler(9);
 
@@ -128,9 +129,15 @@ public class TestTile extends TileEntity implements IGuiHolder<PosGuiData>, ITic
                                                 .child(new ButtonWidget<>()
                                                         .size(60, 18)
                                                         .overlay(IKey.dynamic(() -> "Button " + this.val)))
-                                                .child(new FluidSlot()
-                                                        .margin(2)
-                                                        .syncHandler(SyncHandlers.fluidSlot(this.fluidTank)))
+                                                .child(new Row().widthRel(1f).coverChildrenHeight()
+                                                        .debugName("fluid slot and phantom slot")
+                                                        .child(new FluidSlot()
+                                                                .align(Alignment.CenterLeft)
+                                                                .syncHandler(SyncHandlers.fluidSlot(this.fluidTank)))
+                                                        .child(new ItemSlot()
+                                                                .align(Alignment.CenterRight)
+                                                                .slot(SyncHandlers.phantomItemSlot(phantomInventory, 0)))
+                                                        .margin(2))
                                                 .child(new ButtonWidget<>()
                                                         .size(60, 18)
                                                         .tooltip(tooltip -> {


### PR DESCRIPTION
It's possible to take items out of phantom slots or accidentally delete items because `ContainerCustomizer` doesn't handle `ClickType.SWAP`.
Phantom slots will now copy the hotbar's stack when the key is pressed.
This PR also adds a phantom slot to the `TestTile`.

before:

https://github.com/user-attachments/assets/9e97c024-a359-4547-b829-a9b35b1150a6

after:

https://github.com/user-attachments/assets/0e3c0469-7ebb-4ee7-9982-2a0df946c1ec

