### PR TITLE
Prevent JEI "Delete" tooltip when in exclusion area

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/core/mixin/jei/IngredientGridMixin.java
+++ b/src/main/java/com/cleanroommc/modularui/core/mixin/jei/IngredientGridMixin.java
@@ -1,0 +1,30 @@
+package com.cleanroommc.modularui.core.mixin.jei;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import mezz.jei.gui.GuiScreenHelper;
+import mezz.jei.gui.overlay.IngredientGrid;
+import mezz.jei.gui.overlay.IngredientGridWithNavigation;
+
+import net.minecraft.client.Minecraft;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+
+@Mixin(value = IngredientGridWithNavigation.class, remap = false)
+public abstract class IngredientGridMixin {
+
+    @Shadow
+    @Final
+    private GuiScreenHelper guiScreenHelper;
+
+    @WrapOperation(method = "drawTooltips",
+            at = @At(value = "INVOKE",
+                    target = "Lmezz/jei/gui/overlay/IngredientGrid;drawTooltips(Lnet/minecraft/client/Minecraft;II)V"))
+    private void considerExclusions(IngredientGrid instance, Minecraft minecraft, int mouseX, int mouseY, Operation<Void> original) {
+        if (!guiScreenHelper.isInGuiExclusionArea(mouseX, mouseY))
+            original.call(instance, minecraft, mouseX, mouseY);
+    }
+}

--- a/src/main/resources/mixin.modularui.json
+++ b/src/main/resources/mixin.modularui.json
@@ -15,6 +15,7 @@
   ],
   "mixins": [
     "ContainerAccessor",
-    "FontRendererAccessor"
+    "FontRendererAccessor",
+    "jei.IngredientGridMixin"
   ]
 }


### PR DESCRIPTION
mixins to jei to prevent the "delete" tooltip from showing up when dragging an item over a draggable popup panel when over the jei sidebar
![393039449-c00372f6-7e8a-4b96-a012-779c94c61f4a](https://github.com/user-attachments/assets/b19cd428-cc28-4f6d-ab7f-9ed2f677188a)
