### PR TITLE
Fix Popup Panel Interaction over JEI Elements

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/screen/ClientScreenHandler.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ClientScreenHandler.java
@@ -98,7 +98,7 @@ public class ClientScreenHandler {
         OverlayStack.foreach(ms -> ms.onResize(event.getGui().width, event.getGui().height), false);
     }
 
-    @SubscribeEvent(priority = EventPriority.LOW)
+    @SubscribeEvent(priority = EventPriority.HIGH)
     public static void onGuiInputLow(GuiScreenEvent.KeyboardInputEvent.Pre event) throws IOException {
         defaultContext.updateEventState();
         if (checkGui(event.getGui())) currentScreen.getContext().updateEventState();
@@ -107,7 +107,7 @@ public class ClientScreenHandler {
         }
     }
 
-    @SubscribeEvent(priority = EventPriority.LOW)
+    @SubscribeEvent(priority = EventPriority.HIGH)
     public static void onGuiInputLow(GuiScreenEvent.MouseInputEvent.Pre event) throws IOException {
         defaultContext.updateEventState();
         if (checkGui(event.getGui())) currentScreen.getContext().updateEventState();


### PR DESCRIPTION
since #64, interaction with popup panels (clicking, scrolling, etc) is impossible. Input priority was set to LOW which is after JEI (NORMAL), making JEI consume the inputs and cancelling the event before mui2 can handle them. this pr sets mui2's input listeners to HIGH, so they run before JEI. i've not observed any immediate issues, but i also didn't spend that much time testing.

It might also be possible to mixin into JEI to prevent cancelling the event when inside an excluded area.
or perhaps only manage popup panels at HIGH priority.