### PR TITLE
Fix UITexture not coloring for drawing sub areas

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/drawable/UITexture.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/UITexture.java
@@ -1,6 +1,7 @@
 package com.cleanroommc.modularui.drawable;
 
 import com.cleanroommc.modularui.ModularUI;
+import com.cleanroommc.modularui.api.ITheme;
 import com.cleanroommc.modularui.api.drawable.IDrawable;
 import com.cleanroommc.modularui.screen.viewport.GuiContext;
 import com.cleanroommc.modularui.theme.WidgetTheme;
@@ -141,7 +142,17 @@ public class UITexture implements IDrawable {
         GuiDraw.drawTexture(this.location, x, y, x + width, y + height, this.u0, this.v0, this.u1, this.v1);
     }
 
+    @Deprecated
     public void drawSubArea(float x, float y, float width, float height, float uStart, float vStart, float uEnd, float vEnd) {
+        drawSubArea(x, y, width, height, uStart, vStart, uEnd, vEnd, WidgetTheme.getDefault());
+    }
+
+    public void drawSubArea(float x, float y, float width, float height, float uStart, float vStart, float uEnd, float vEnd, WidgetTheme widgetTheme) {
+        if (canApplyTheme()) {
+            Color.setGlColor(widgetTheme.getColor());
+        } else {
+            Color.setGlColorOpaque(Color.WHITE.main);
+        }
         GuiDraw.drawTexture(this.location, x, y, x + width, y + height, lerpU(uStart), lerpV(vStart), lerpU(uEnd), lerpV(vEnd));
     }
 

--- a/src/main/java/com/cleanroommc/modularui/widgets/ProgressWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/ProgressWidget.java
@@ -62,7 +62,7 @@ public class ProgressWidget extends Widget<ProgressWidget> {
         float progress = getCurrentProgress();
         if (this.fullTexture[0] != null && progress > 0) {
             if (this.direction == Direction.CIRCULAR_CW) {
-                drawCircular(progress);
+                drawCircular(progress, widgetTheme);
                 return;
             }
             if (progress >= 1) {
@@ -91,7 +91,7 @@ public class ProgressWidget extends Widget<ProgressWidget> {
                         y = getArea().height - height;
                         break;
                 }
-                this.fullTexture[0].drawSubArea(x, y, width, height, u0, v0, u1, v1);
+                this.fullTexture[0].drawSubArea(x, y, width, height, u0, v0, u1, v1, widgetTheme);
             }
         }
     }
@@ -103,7 +103,7 @@ public class ProgressWidget extends Widget<ProgressWidget> {
         return (float) (Math.floor(uv * this.imageSize) / this.imageSize);
     }
 
-    private void drawCircular(float progress) {
+    private void drawCircular(float progress, WidgetTheme widgetTheme) {
         float[] subAreas = {
                 getProgressUV(MathHelper.clamp(progress / 0.25f, 0, 1)),
                 getProgressUV(MathHelper.clamp((progress - 0.25f) / 0.25f, 0, 1)),
@@ -118,7 +118,7 @@ public class ProgressWidget extends Widget<ProgressWidget> {
                 0, getArea().height - progressScaled,
                 halfWidth, progressScaled,
                 0.0f, 1.0f - progressScaled / halfHeight,
-                1.0f, 1.0f
+                1.0f, 1.0f, widgetTheme
         ); // BL, draw UP
 
         progressScaled = subAreas[1] * halfWidth;
@@ -126,7 +126,8 @@ public class ProgressWidget extends Widget<ProgressWidget> {
                 0, 0,
                 progressScaled, halfHeight,
                 0.0f, 0.0f,
-                progressScaled / (halfWidth), 1.0f
+                progressScaled / (halfWidth), 1.0f,
+                widgetTheme
         ); // TL, draw RIGHT
 
         progressScaled = subAreas[2] * halfHeight;
@@ -134,7 +135,8 @@ public class ProgressWidget extends Widget<ProgressWidget> {
                 halfWidth, 0,
                 halfWidth, progressScaled,
                 0.0f, 0.0f,
-                1.0f, progressScaled / halfHeight
+                1.0f, progressScaled / halfHeight,
+                widgetTheme
         ); // TR, draw DOWN
 
         progressScaled = subAreas[3] * halfWidth;
@@ -142,7 +144,7 @@ public class ProgressWidget extends Widget<ProgressWidget> {
                 getArea().width - progressScaled, halfHeight,
                 progressScaled, halfHeight,
                 1.0f - progressScaled / halfWidth, 0.0f,
-                1.0f, 1.0f
+                1.0f, 1.0f, widgetTheme
         ); // BR, draw LEFT
     }
 


### PR DESCRIPTION
the `drawSubArea()` method does not properly color the texture with respect to current the widget theme
this is fixed now, and the old method is marked as deprecated like in IDrawable