### PR TITLE
fix dropping items when clicking on widgets outside of panel

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/screen/GuiContainerWrapper.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/GuiContainerWrapper.java
@@ -36,4 +36,9 @@ public class GuiContainerWrapper extends GuiContainer implements IMuiScreen {
     public boolean doesGuiPauseGame() {
         return this.screen != null && this.screen.doesPauseGame();
     }
+
+    @Override
+    protected boolean hasClickedOutside(int mx, int my, int guiLeft, int guiTop) {
+        return this.screen.hasClickedOutside();
+    }
 }

--- a/src/main/java/com/cleanroommc/modularui/screen/ModularScreen.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/ModularScreen.java
@@ -460,6 +460,15 @@ public class ModularScreen {
         return pausesGame;
     }
 
+    public boolean hasClickedOutside() {
+        for (ModularPanel openPanel : getPanelManager().getOpenPanels()) {
+            if (openPanel.getTopHovering() != null) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     @SuppressWarnings("unchecked")
     private <T extends IGuiAction> List<T> getGuiActionListeners(Class<T> clazz) {
         return (List<T>) this.guiActionListeners.getOrDefault(clazz, Collections.emptyList());


### PR DESCRIPTION
fixes #110 
fixes dropping items in synced containers (ones that use GuiContainerWrapper) when clicking on widgets that are outside of the main panel