### PR TITLE
Fix 1px offset with player inventory

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/widgets/SlotGroupWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/SlotGroupWidget.java
@@ -43,7 +43,7 @@ public class SlotGroupWidget extends ParentWidget<SlotGroupWidget> {
         for (int i = 0; i < 9; i++) {
             slotGroupWidget.child(slotConsumer.apply(i, new ItemSlot())
                     .syncHandler(key, i)
-                    .pos(i * 18, 3 * 18 + 5)
+                    .pos(i * 18, 3 * 18 + 4)
                     .debugName("slot_" + i));
         }
         for (int i = 0; i < 27; i++) {


### PR DESCRIPTION
↓MUI1
![2025-02-18_11 43 04](https://github.com/user-attachments/assets/dbcb8a5f-e1ae-4bd5-b0ac-17e4512df136)
↓Vanilla Chest
![2025-02-18_13 42 10](https://github.com/user-attachments/assets/57501b16-3a97-4b14-9165-378275bce96d)
↓MUI2
![2025-02-18_13 41 22](https://github.com/user-attachments/assets/2ba6aca6-2ed3-43a8-8d15-97264e8ffbac)
