### PR TITLE
Correct space between tooltip lines

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/api/drawable/IRichTextBuilder.java
+++ b/src/main/java/com/cleanroommc/modularui/api/drawable/IRichTextBuilder.java
@@ -30,7 +30,16 @@ public interface IRichTextBuilder<T extends IRichTextBuilder<T>> {
     }
 
     default T newLine() {
-        return add(IKey.LINE_FEED);
+        return newLine(1);
+    }
+
+    default T newLine(int space) {
+        if (space > 0) {
+            getRichText().add(IKey.LINE_FEED).addLine(Spacer.of(space));
+        } else {
+            getRichText().add(IKey.LINE_FEED);
+        }
+        return getThis();
     }
 
     default T space() {

--- a/src/main/java/com/cleanroommc/modularui/screen/RichTooltip.java
+++ b/src/main/java/com/cleanroommc/modularui/screen/RichTooltip.java
@@ -327,7 +327,7 @@ public class RichTooltip implements IRichTextBuilder<RichTooltip> {
 
     public RichTooltip addFromItem(ItemStack item) {
         List<String> lines = MCHelper.getItemToolTip(item);
-        add(lines.get(0)).spaceLine(2);
+        add(lines.get(0)).spaceLine(3);
         for (int i = 1, n = lines.size(); i < n; i++) {
             add(lines.get(i)).newLine();
         }


### PR DESCRIPTION
Vanilla has 1px more space between tooltip lines. This PR makes MUI tooltip look more like vanilla. Please tell me if this is not the right way to achieve it.

↓Before
![2025-02-19_19 19 20](https://github.com/user-attachments/assets/a44d71ad-b491-4859-8a42-dc17472a4130)
↓After
![2025-02-19_19 22 04](https://github.com/user-attachments/assets/f7bed76b-f724-40ba-8ab0-243c27755c37)
↓Vanilla
![2025-02-19_19 22 13](https://github.com/user-attachments/assets/4956b3a9-8121-41e7-9bfe-37024b5d1912)
