### PR TITLE
Allow collapsing disabled child widgets + sizing fixes

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/api/layout/ILayoutWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/api/layout/ILayoutWidget.java
@@ -1,5 +1,7 @@
 package com.cleanroommc.modularui.api.layout;
 
+import com.cleanroommc.modularui.api.widget.IWidget;
+
 /**
  * This is responsible for laying out widgets.
  */
@@ -17,4 +19,14 @@ public interface ILayoutWidget {
      * The last call guarantees, that this widget is fully calculated.
      */
     default void postLayoutWidgets() {}
+
+    /**
+     * Called when determining wrapping size of this widget.
+     * If this method returns true, size and margin of the queried child will be ignored for calculation.
+     * Typically return true when the child is disabled and you want to collapse it for layout.
+     * This method should also be used for layouting children with {@link #layoutWidgets} if it might return true.
+     */
+    default boolean shouldIgnoreChildSize(IWidget child) {
+        return false;
+    }
 }

--- a/src/main/java/com/cleanroommc/modularui/widget/sizer/Area.java
+++ b/src/main/java/com/cleanroommc/modularui/widget/sizer/Area.java
@@ -21,6 +21,8 @@ public class Area extends Rectangle implements IUnResizeable {
 
     public static final Area SHARED = new Area();
 
+    public static final Area ZERO = new Area();
+
     /**
      * relative position (in most cases the direct parent)
      */

--- a/src/main/java/com/cleanroommc/modularui/widget/sizer/Box.java
+++ b/src/main/java/com/cleanroommc/modularui/widget/sizer/Box.java
@@ -10,6 +10,8 @@ public class Box {
 
     public static final Box SHARED = new Box();
 
+    public static final Box ZERO = new Box();
+
     public int left;
     public int top;
     public int right;
@@ -73,5 +75,15 @@ public class Box {
 
     public int getEnd(GuiAxis axis) {
         return axis.isHorizontal() ? this.right : this.bottom;
+    }
+
+    @Override
+    public String toString() {
+        return "Box{" +
+                "left=" + left +
+                ", top=" + top +
+                ", right=" + right +
+                ", bottom=" + bottom +
+                '}';
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/widget/sizer/Flex.java
+++ b/src/main/java/com/cleanroommc/modularui/widget/sizer/Flex.java
@@ -422,16 +422,17 @@ public class Flex implements IResizeable, IPositioned<Flex> {
         return isFullyCalculated();
     }
 
-    private void coverChildrenForLayout(IWidget widget) {
-        List<IWidget> children = widget.getChildren();
+     private void coverChildrenForLayout(IWidget widget) {
+         List<IWidget> children = widget.getChildren();
         Box padding = this.parent.getArea().getPadding();
         // first calculate the area the children span
         int x1 = Integer.MIN_VALUE, y1 = Integer.MIN_VALUE;
         int w = 0, h = 0;
         for (IWidget child : children) {
-            Box margin = child.getArea().getMargin();
+            final boolean shouldIgnoreChildSize = ((ILayoutWidget) this.parent).shouldIgnoreChildSize(child);
+            Box margin = shouldIgnoreChildSize ? Box.ZERO : child.getArea().getMargin();
             IResizeable resizeable = child.resizer();
-            Area area = child.getArea();
+            Area area = shouldIgnoreChildSize ? Area.ZERO : child.getArea();
             if (this.x.dependsOnChildren() && resizeable.isWidthCalculated()) {
                 w = Math.max(w, area.requestedWidth() + padding.horizontal());
                 if (resizeable.isXCalculated()) {

--- a/src/main/java/com/cleanroommc/modularui/widget/sizer/Flex.java
+++ b/src/main/java/com/cleanroommc/modularui/widget/sizer/Flex.java
@@ -422,8 +422,8 @@ public class Flex implements IResizeable, IPositioned<Flex> {
         return isFullyCalculated();
     }
 
-     private void coverChildrenForLayout(IWidget widget) {
-         List<IWidget> children = widget.getChildren();
+    private void coverChildrenForLayout(IWidget widget) {
+        List<IWidget> children = widget.getChildren();
         Box padding = this.parent.getArea().getPadding();
         // first calculate the area the children span
         int x1 = Integer.MIN_VALUE, y1 = Integer.MIN_VALUE;

--- a/src/main/java/com/cleanroommc/modularui/widgets/ListWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/ListWidget.java
@@ -8,13 +8,11 @@ import com.cleanroommc.modularui.api.widget.IWidget;
 import com.cleanroommc.modularui.screen.viewport.ModularGuiContext;
 import com.cleanroommc.modularui.theme.WidgetTheme;
 import com.cleanroommc.modularui.widget.AbstractScrollWidget;
-import com.cleanroommc.modularui.widget.scroll.HorizontalScrollData;
 import com.cleanroommc.modularui.widget.scroll.ScrollData;
 import com.cleanroommc.modularui.widget.scroll.VerticalScrollData;
 
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.function.IntFunction;
 
@@ -29,6 +27,7 @@ public class ListWidget<I extends IWidget, W extends ListWidget<I, W>> extends A
     private ScrollData scrollData;
     private IIcon childSeparator;
     private final IntList separatorPositions = new IntArrayList();
+    private boolean collapseDisabledChild = false;
 
     public ListWidget() {
         super(null, null);
@@ -70,6 +69,7 @@ public class ListWidget<I extends IWidget, W extends ListWidget<I, W>> extends A
         int separatorSize = getSeparatorSize();
         int p = getArea().getPadding().getStart(axis);
         for (IWidget widget : getChildren()) {
+            if (shouldIgnoreChildSize(widget)) continue;
             if (axis.isVertical() ?
                     widget.getFlex().hasYPos() || !widget.resizer().isHeightCalculated() :
                     widget.getFlex().hasXPos() || !widget.resizer().isWidthCalculated()) {
@@ -87,6 +87,10 @@ public class ListWidget<I extends IWidget, W extends ListWidget<I, W>> extends A
             p += separatorSize;
         }
         getScrollData().setScrollSize(p + getArea().getPadding().getEnd(axis));
+    }
+
+    public boolean shouldIgnoreChildSize(IWidget child) {
+        return this.collapseDisabledChild && !child.isEnabled();
     }
 
     @Override
@@ -146,6 +150,14 @@ public class ListWidget<I extends IWidget, W extends ListWidget<I, W>> extends A
         for (int i = 0; i < amount; i++) {
             child(widgetCreator.apply(i));
         }
+        return getThis();
+    }
+
+    /**
+     * Configures this widget to collapse disabled child widgets.
+     */
+    public W collapseDisabledChild() {
+        this.collapseDisabledChild = true;
         return getThis();
     }
 }

--- a/src/main/java/com/cleanroommc/modularui/widgets/ListWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/ListWidget.java
@@ -89,6 +89,7 @@ public class ListWidget<I extends IWidget, W extends ListWidget<I, W>> extends A
         getScrollData().setScrollSize(p + getArea().getPadding().getEnd(axis));
     }
 
+    @Override
     public boolean shouldIgnoreChildSize(IWidget child) {
         return this.collapseDisabledChild && !child.isEnabled();
     }

--- a/src/main/java/com/cleanroommc/modularui/widgets/layout/Flow.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/layout/Flow.java
@@ -78,6 +78,8 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
             totalSize += widget.getArea().requestedSize(this.axis);
         }
 
+        final int spaceCount = Math.max(amount - 1, 0);
+
         if (maa == Alignment.MainAxis.SPACE_BETWEEN || maa == Alignment.MainAxis.SPACE_AROUND) {
             if (expandedAmount > 0) {
                 maa = Alignment.MainAxis.START;
@@ -85,7 +87,7 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
                 space = 0;
             }
         }
-        totalSize += space * (getChildren().size() - 1);
+        totalSize += space * spaceCount;
 
         if (expandedAmount > 0 && hasSize) {
             int newSize = (size - totalSize - padding.getTotal(this.axis)) / expandedAmount;
@@ -125,7 +127,7 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
 
             lastP += widget.getArea().requestedSize(this.axis) + space;
             if (hasSize && maa == Alignment.MainAxis.SPACE_BETWEEN) {
-                lastP += (size - totalSize) / (getChildren().size() - 1);
+                lastP += (size - totalSize) / spaceCount;
             }
         }
     }

--- a/src/main/java/com/cleanroommc/modularui/widgets/layout/Flow.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/layout/Flow.java
@@ -4,7 +4,6 @@ import com.cleanroommc.modularui.api.GuiAxis;
 import com.cleanroommc.modularui.api.layout.ILayoutWidget;
 import com.cleanroommc.modularui.api.widget.IWidget;
 import com.cleanroommc.modularui.utils.Alignment;
-import com.cleanroommc.modularui.widget.AbstractParentWidget;
 import com.cleanroommc.modularui.widget.ParentWidget;
 import com.cleanroommc.modularui.widget.sizer.Box;
 
@@ -35,6 +34,10 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
      * Does not work with {@link Alignment.MainAxis#SPACE_BETWEEN} and {@link Alignment.MainAxis#SPACE_AROUND}.
      */
     private int spaceBetween = 0;
+    /**
+     * Whether disabled child widgets should be collapsed for display.
+     */
+    private boolean collapseDisabledChild = false;
 
     public Flow(GuiAxis axis) {
         this.axis = axis;
@@ -66,6 +69,8 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
 
         // calculate total size and maximum width
         for (IWidget widget : getChildren()) {
+            // ignore disabled child if configured as such
+            if (shouldIgnoreChildSize(widget)) continue;
             // exclude self positioned (Y) children
             if (widget.flex().hasPos(this.axis)) continue;
             amount++;
@@ -89,6 +94,8 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
         if (expandedAmount > 0 && hasSize) {
             int newSize = (size - totalSize - padding.getTotal(this.axis)) / expandedAmount;
             for (IWidget widget : getChildren()) {
+                // ignore disabled child if configured as such
+                if (shouldIgnoreChildSize(widget)) continue;
                 // exclude self positioned (Y) children
                 if (widget.flex().hasPos(this.axis)) continue;
                 if (widget.flex().isExpanded()) {
@@ -109,6 +116,8 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
         }
 
         for (IWidget widget : getChildren()) {
+            // ignore disabled child if configured as such
+            if (shouldIgnoreChildSize(widget)) continue;
             // exclude self positioned (Y) children
             if (widget.flex().hasPos(this.axis)) continue;
             Box margin = widget.getArea().getMargin();
@@ -152,6 +161,10 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
         }
     }
 
+    public boolean shouldIgnoreChildSize(IWidget child) {
+        return this.collapseDisabledChild && !child.isEnabled();
+    }
+
     public Flow crossAxisAlignment(Alignment.CrossAxis caa) {
         this.caa = caa;
         return this;
@@ -164,6 +177,14 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
 
     public Flow childPadding(int spaceBetween) {
         this.spaceBetween = spaceBetween;
+        return this;
+    }
+
+    /**
+     * Configures this widget to collapse disabled child widgets.
+     */
+    public Flow collapseDisabledChild() {
+        this.collapseDisabledChild = true;
         return this;
     }
 

--- a/src/main/java/com/cleanroommc/modularui/widgets/layout/Flow.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/layout/Flow.java
@@ -161,6 +161,7 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
         }
     }
 
+    @Override
     public boolean shouldIgnoreChildSize(IWidget child) {
         return this.collapseDisabledChild && !child.isEnabled();
     }

--- a/src/main/java/com/cleanroommc/modularui/widgets/layout/Flow.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/layout/Flow.java
@@ -54,9 +54,6 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
         if (!hasSize && maa != Alignment.MainAxis.START) {
             maa = Alignment.MainAxis.START;
         }
-        if (maa == Alignment.MainAxis.SPACE_BETWEEN && getChildren().size() == 1) {
-            maa = Alignment.MainAxis.CENTER;
-        }
         int space = this.spaceBetween;
 
         int totalSize = 0;
@@ -78,6 +75,9 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
             totalSize += widget.getArea().requestedSize(this.axis);
         }
 
+        if (amount <= 1 && maa == Alignment.MainAxis.SPACE_BETWEEN) {
+            maa = Alignment.MainAxis.CENTER;
+        }
         final int spaceCount = Math.max(amount - 1, 0);
 
         if (maa == Alignment.MainAxis.SPACE_BETWEEN || maa == Alignment.MainAxis.SPACE_AROUND) {

--- a/src/main/java/com/cleanroommc/modularui/widgets/layout/Flow.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/layout/Flow.java
@@ -52,11 +52,7 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
         Box padding = getArea().getPadding();
         Alignment.MainAxis maa = this.maa;
         if (!hasSize && maa != Alignment.MainAxis.START) {
-            if (flex().dependsOnChildren(axis)) {
-                maa = Alignment.MainAxis.START;
-            } else {
-                throw new IllegalStateException("Alignment.MainAxis other than start need the size to be calculated!");
-            }
+            maa = Alignment.MainAxis.START;
         }
         if (maa == Alignment.MainAxis.SPACE_BETWEEN && getChildren().size() == 1) {
             maa = Alignment.MainAxis.CENTER;

--- a/src/main/java/com/cleanroommc/modularui/widgets/layout/Flow.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/layout/Flow.java
@@ -47,16 +47,16 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
     @Override
     public void layoutWidgets() {
         if (!hasChildren()) return;
-        boolean hasSize = resizer().isSizeCalculated(this.axis);
-        int size = getArea().getSize(axis);
-        Box padding = getArea().getPadding();
+        final boolean hasSize = resizer().isSizeCalculated(this.axis);
+        final Box padding = getArea().getPadding();
+        final int size = getArea().getSize(axis) - padding.getTotal(this.axis);
         Alignment.MainAxis maa = this.maa;
         if (!hasSize && maa != Alignment.MainAxis.START) {
             maa = Alignment.MainAxis.START;
         }
         int space = this.spaceBetween;
 
-        int totalSize = 0;
+        int childrenSize = 0;
         int expandedAmount = 0;
         int amount = 0;
 
@@ -69,10 +69,10 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
             amount++;
             if (widget.flex().isExpanded()) {
                 expandedAmount++;
-                totalSize += widget.getArea().getMargin().getTotal(this.axis);
+                childrenSize += widget.getArea().getMargin().getTotal(this.axis);
                 continue;
             }
-            totalSize += widget.getArea().requestedSize(this.axis);
+            childrenSize += widget.getArea().requestedSize(this.axis);
         }
 
         if (amount <= 1 && maa == Alignment.MainAxis.SPACE_BETWEEN) {
@@ -87,10 +87,10 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
                 space = 0;
             }
         }
-        totalSize += space * spaceCount;
+        childrenSize += space * spaceCount;
 
         if (expandedAmount > 0 && hasSize) {
-            int newSize = (size - totalSize - padding.getTotal(this.axis)) / expandedAmount;
+            int newSize = (size - childrenSize) / expandedAmount;
             for (IWidget widget : getChildren()) {
                 // ignore disabled child if configured as such
                 if (shouldIgnoreChildSize(widget)) continue;
@@ -107,9 +107,9 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
         int lastP = padding.getStart(this.axis);
         if (hasSize) {
             if (maa == Alignment.MainAxis.CENTER) {
-                lastP = (int) (size / 2f - totalSize / 2f);
+                lastP += (int) (size / 2f - childrenSize / 2f);
             } else if (maa == Alignment.MainAxis.END) {
-                lastP = size - totalSize;
+                lastP += size - childrenSize;
             }
         }
 
@@ -127,7 +127,7 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
 
             lastP += widget.getArea().requestedSize(this.axis) + space;
             if (hasSize && maa == Alignment.MainAxis.SPACE_BETWEEN) {
-                lastP += (size - totalSize) / spaceCount;
+                lastP += (size - childrenSize) / spaceCount;
             }
         }
     }

--- a/src/main/java/com/cleanroommc/modularui/widgets/layout/Flow.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/layout/Flow.java
@@ -67,11 +67,11 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
         int expandedAmount = 0;
         int amount = 0;
 
-        // calculate total size and maximum width
+        // calculate total size
         for (IWidget widget : getChildren()) {
             // ignore disabled child if configured as such
             if (shouldIgnoreChildSize(widget)) continue;
-            // exclude self positioned (Y) children
+            // exclude children whose position of main axis is fixed
             if (widget.flex().hasPos(this.axis)) continue;
             amount++;
             if (widget.flex().isExpanded()) {
@@ -96,7 +96,7 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
             for (IWidget widget : getChildren()) {
                 // ignore disabled child if configured as such
                 if (shouldIgnoreChildSize(widget)) continue;
-                // exclude self positioned (Y) children
+                // exclude children whose position of main axis is fixed
                 if (widget.flex().hasPos(this.axis)) continue;
                 if (widget.flex().isExpanded()) {
                     widget.getArea().setSize(this.axis, newSize);
@@ -118,11 +118,11 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
         for (IWidget widget : getChildren()) {
             // ignore disabled child if configured as such
             if (shouldIgnoreChildSize(widget)) continue;
-            // exclude self positioned (Y) children
+            // exclude children whose position of main axis is fixed
             if (widget.flex().hasPos(this.axis)) continue;
             Box margin = widget.getArea().getMargin();
 
-            // set calculated relative Y pos and set bottom margin for next widget
+            // set calculated relative main axis pos and set end margin for next widget
             widget.getArea().setRelativePoint(this.axis, lastP + margin.getStart(this.axis));
             widget.resizer().setPosResized(this.axis, true);
             widget.resizer().setMarginPaddingApplied(this.axis, true);
@@ -141,20 +141,20 @@ public class Flow extends ParentWidget<Flow> implements ILayoutWidget, IExpander
         Box padding = getArea().getPadding();
         boolean hasWidth = resizer().isSizeCalculated(other);
         for (IWidget widget : getChildren()) {
-            // exclude self positioned (Y) children
+            // exclude children whose position of main axis is fixed
             if (widget.flex().hasPos(this.axis)) continue;
             Box margin = widget.getArea().getMargin();
-            // don't align auto positioned (X) children in X
+            // don't align auto positioned children in cross axis
             if (!widget.flex().hasPos(other) && widget.resizer().isSizeCalculated(other)) {
-                int x = margin.getStart(other) + padding.getStart(other);
+                int crossAxisPos = margin.getStart(other) + padding.getStart(other);
                 if (hasWidth) {
                     if (this.caa == Alignment.CrossAxis.CENTER) {
-                        x = (int) (width / 2f - widget.getArea().getSize(other) / 2f);
+                        crossAxisPos = (int) (width / 2f - widget.getArea().getSize(other) / 2f);
                     } else if (this.caa == Alignment.CrossAxis.END) {
-                        x = width - widget.getArea().getSize(other) - margin.getEnd(other) - padding.getStart(other);
+                        crossAxisPos = width - widget.getArea().getSize(other) - margin.getEnd(other) - padding.getStart(other);
                     }
                 }
-                widget.getArea().setRelativePoint(other, x);
+                widget.getArea().setRelativePoint(other, crossAxisPos);
                 widget.resizer().setPosResized(other, true);
                 widget.resizer().setMarginPaddingApplied(other, true);
             }

--- a/src/main/java/com/cleanroommc/modularui/widgets/layout/Grid.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/layout/Grid.java
@@ -101,6 +101,7 @@ public class Grid extends AbstractScrollWidget<IWidget, Grid> implements ILayout
         }
     }
 
+    @Override
     public boolean shouldIgnoreChildSize(IWidget child) {
         return child == null || (this.collapseDisabledChild && !child.isEnabled());
     }

--- a/src/main/java/com/cleanroommc/modularui/widgets/layout/Grid.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/layout/Grid.java
@@ -27,6 +27,7 @@ public class Grid extends AbstractScrollWidget<IWidget, Grid> implements ILayout
     private int minRowHeight = 5, minColWidth = 5;
     private Alignment alignment = Alignment.Center;
     private boolean dirty = false;
+    private boolean collapseDisabledChild = false;
 
     public Grid() {
         super(null, null);
@@ -67,7 +68,7 @@ public class Grid extends AbstractScrollWidget<IWidget, Grid> implements ILayout
                 if (i == 0) {
                     colSizes.add(this.minColWidth);
                 }
-                if (child != null && child.isEnabled()) {
+                if (!shouldIgnoreChildSize(child)) {
                     rowSizes.set(i, Math.max(rowSizes.getInt(i), getElementHeight(child.getArea())));
                     colSizes.set(j, Math.max(colSizes.getInt(j), getElementWidth(child.getArea())));
                 }
@@ -100,6 +101,10 @@ public class Grid extends AbstractScrollWidget<IWidget, Grid> implements ILayout
         }
     }
 
+    public boolean shouldIgnoreChildSize(IWidget child) {
+        return child == null || (this.collapseDisabledChild && !child.isEnabled());
+    }
+
     @Override
     public @NotNull List<IWidget> getChildren() {
         if (this.dirty) {
@@ -120,7 +125,7 @@ public class Grid extends AbstractScrollWidget<IWidget, Grid> implements ILayout
         for (List<IWidget> row : this.matrix) {
             int rowHeight = 0;
             for (IWidget child : row) {
-                if (child != null) {
+                if (!shouldIgnoreChildSize(child)) {
                     rowHeight = Math.max(rowHeight, getElementHeight(child.getArea()));
                 }
             }
@@ -139,7 +144,7 @@ public class Grid extends AbstractScrollWidget<IWidget, Grid> implements ILayout
                 if (i == 0) {
                     colSizes.add(this.minColWidth);
                 }
-                if (child != null) {
+                if (!shouldIgnoreChildSize(child)) {
                     colSizes.set(j, Math.max(colSizes.getInt(j), getElementWidth(child.getArea())));
                 }
                 j++;
@@ -279,6 +284,14 @@ public class Grid extends AbstractScrollWidget<IWidget, Grid> implements ILayout
 
     public Grid minElementMarginBottom(int val) {
         this.minElementMargin.bottom(val);
+        return getThis();
+    }
+
+    /**
+     * Configures this widget to collapse row/column if all the child widgets in that axis are disabled.
+     */
+    public Grid collapseDisabledChild() {
+        this.collapseDisabledChild = true;
         return getThis();
     }
 


### PR DESCRIPTION
This is the code I used to test behaviors:
```java
public ModularPanel buildUI(PosGuiData guiData, PanelSyncManager guiSyncManager, UISettings settings) {
    ModularPanel panel = new ModularPanel("test_tile");
    panel.child(new Rectangle().setColor(Color.RED.main).asWidget().alignX(0.5f).alignY(0.4f).size(1));
    Flow row = Flow.row();
    panel.child(row
            .center()
            .coverChildrenHeight()
            .width(150)
            .padding(2)
            // .paddingLeft(20)
            .collapseDisabledChild()
            .mainAxisAlignment(Alignment.MainAxis.SPACE_BETWEEN)
            .childPadding(3)
            .background(GuiTextures.DISPLAY)
            .child(new TestButton(row)
                    .overlay(IKey.str("1")))
            .child(new TestButton(row)
                    .overlay(IKey.str("2"))
                    .marginLeft(7))
            .child(new TestButton(row)
                    .overlay(IKey.str("3")))
            .child(new TestButton(row)
                    .overlay(IKey.str("4"))
                    .marginRight(7))
            .child(new TestButton(row)
                    .overlay(IKey.str("5"))));
    return panel;
}

private static class TestButton extends ButtonWidget<TestButton> {
    private TestButton(IWidget widget) {
        onMousePressed($ -> {
            setEnabled(false);
            if (NetworkUtils.isClient()) {
                WidgetTree.resize(widget);
            }
            return true;
        });
    }
}
```