### PR TITLE
Don't try to resize widget tree on server

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/widget/WidgetTree.java
+++ b/src/main/java/com/cleanroommc/modularui/widget/WidgetTree.java
@@ -8,6 +8,7 @@ import com.cleanroommc.modularui.api.layout.IViewport;
 import com.cleanroommc.modularui.api.widget.IGuiElement;
 import com.cleanroommc.modularui.api.widget.ISynced;
 import com.cleanroommc.modularui.api.widget.IWidget;
+import com.cleanroommc.modularui.network.NetworkUtils;
 import com.cleanroommc.modularui.screen.ModularPanel;
 import com.cleanroommc.modularui.screen.viewport.ModularGuiContext;
 import com.cleanroommc.modularui.theme.WidgetTheme;
@@ -231,6 +232,7 @@ public class WidgetTree {
     }
 
     public static void resize(IWidget parent) {
+        if (!NetworkUtils.isClient()) return;
         // TODO check if widget has a parent which depends on its children
         // resize each widget and calculate their relative pos
         if (!resizeWidget(parent, true) && !resizeWidget(parent, false)) {


### PR DESCRIPTION
Calling this method on server results in crash saying `(widget) is not in a valid state!`, which doesn't give any hint on actual cause. By inserting early return, it not only prevents obscure crash but also removes the need for side check boilerplate.