### PR TITLE
Expose ModularSyncManager#getMainPSM to public

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/value/sync/ModularSyncManager.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/ModularSyncManager.java
@@ -47,8 +47,7 @@ public class ModularSyncManager {
         mainPSM.syncValue(CURSOR_KEY, this.cursorSlotSyncHandler);
     }
 
-    // not sure why there was no getter before, need to check if this can be public
-    PanelSyncManager getMainPSM() {
+    public PanelSyncManager getMainPSM() {
         return mainPSM;
     }
 


### PR DESCRIPTION
This method is useful for server logging tool to figure out what GUI the player opened.