### PR TITLE
Fix various JEI ghost hovering/dragging issues

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/core/mixin/jei/GhostIngredientDragManagerAccessor.java
+++ b/src/main/java/com/cleanroommc/modularui/core/mixin/jei/GhostIngredientDragManagerAccessor.java
@@ -2,6 +2,7 @@ package com.cleanroommc.modularui.core.mixin.jei;
 
 import mezz.jei.gui.ghost.GhostIngredientDrag;
 import mezz.jei.gui.ghost.GhostIngredientDragManager;
+import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
 
@@ -9,8 +10,8 @@ import org.spongepowered.asm.mixin.gen.Accessor;
 public interface GhostIngredientDragManagerAccessor {
 
     @Accessor
-    GhostIngredientDrag<?> getGhostIngredientDrag();
+    @Nullable GhostIngredientDrag<?> getGhostIngredientDrag();
 
     @Accessor
-    Object getHoveredIngredient();
+    @Nullable Object getHoveredIngredient();
 }

--- a/src/main/java/com/cleanroommc/modularui/integration/jei/ModularUIJeiPlugin.java
+++ b/src/main/java/com/cleanroommc/modularui/integration/jei/ModularUIJeiPlugin.java
@@ -51,7 +51,6 @@ public class ModularUIJeiPlugin implements IModPlugin {
     }
 
     public static boolean draggingValidIngredient(JeiGhostIngredientSlot<?> ingredientSlot) {
-        if (Config.isCheatItemsEnabled()) return false;
         Object dragging = getDraggedObject();
         if (dragging == null) return false;
         return ingredientSlot.castGhostIngredientIfValid(dragging) != null;

--- a/src/main/java/com/cleanroommc/modularui/integration/jei/ModularUIJeiPlugin.java
+++ b/src/main/java/com/cleanroommc/modularui/integration/jei/ModularUIJeiPlugin.java
@@ -15,6 +15,7 @@ import mezz.jei.config.Config;
 import mezz.jei.gui.ghost.GhostIngredientDrag;
 import mezz.jei.gui.ghost.GhostIngredientDragManager;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @JEIPlugin
 public class ModularUIJeiPlugin implements IModPlugin {
@@ -30,7 +31,7 @@ public class ModularUIJeiPlugin implements IModPlugin {
     }
 
     @Override
-    public void onRuntimeAvailable(IJeiRuntime jeiRuntime) {
+    public void onRuntimeAvailable(@NotNull IJeiRuntime jeiRuntime) {
         ModularUIJeiPlugin.runtime = jeiRuntime;
     }
 
@@ -51,15 +52,23 @@ public class ModularUIJeiPlugin implements IModPlugin {
 
     public static boolean draggingValidIngredient(JeiGhostIngredientSlot<?> ingredientSlot) {
         if (Config.isCheatItemsEnabled()) return false;
-        Object dragging = getGhostDrag();
+        Object dragging = getDraggedObject();
         if (dragging == null) return false;
         return ingredientSlot.castGhostIngredientIfValid(dragging) != null;
     }
 
+    @Nullable
     public static GhostIngredientDrag<?> getGhostDrag() {
         return ((GhostIngredientDragManagerAccessor) getGhostDragManager()).getGhostIngredientDrag();
     }
 
+    @Nullable
+    public static Object getDraggedObject() {
+        GhostIngredientDrag<?> drag = getGhostDrag();
+        return drag == null ? null : drag.getIngredient();
+    }
+
+    @Nullable
     public static Object getHoverdObject() {
         return ((GhostIngredientDragManagerAccessor) getGhostDragManager()).getHoveredIngredient();
     }

--- a/src/main/java/com/cleanroommc/modularui/integration/jei/ModularUIJeiPlugin.java
+++ b/src/main/java/com/cleanroommc/modularui/integration/jei/ModularUIJeiPlugin.java
@@ -49,6 +49,13 @@ public class ModularUIJeiPlugin implements IModPlugin {
         return ingredientSlot.castGhostIngredientIfValid(hovered) != null;
     }
 
+    public static boolean draggingValidIngredient(JeiGhostIngredientSlot<?> ingredientSlot) {
+        if (Config.isCheatItemsEnabled()) return false;
+        Object dragging = getGhostDrag();
+        if (dragging == null) return false;
+        return ingredientSlot.castGhostIngredientIfValid(dragging) != null;
+    }
+
     public static GhostIngredientDrag<?> getGhostDrag() {
         return ((GhostIngredientDragManagerAccessor) getGhostDragManager()).getGhostIngredientDrag();
     }

--- a/src/main/java/com/cleanroommc/modularui/widgets/slot/FluidSlot.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/slot/FluidSlot.java
@@ -1,5 +1,6 @@
 package com.cleanroommc.modularui.widgets.slot;
 
+import com.cleanroommc.modularui.ModularUI;
 import com.cleanroommc.modularui.api.ITheme;
 import com.cleanroommc.modularui.api.drawable.IDrawable;
 import com.cleanroommc.modularui.api.drawable.IKey;
@@ -8,6 +9,7 @@ import com.cleanroommc.modularui.drawable.GuiDraw;
 import com.cleanroommc.modularui.drawable.text.TextRenderer;
 import com.cleanroommc.modularui.integration.jei.JeiGhostIngredientSlot;
 import com.cleanroommc.modularui.integration.jei.JeiIngredientProvider;
+import com.cleanroommc.modularui.integration.jei.ModularUIJeiPlugin;
 import com.cleanroommc.modularui.screen.ModularScreen;
 import com.cleanroommc.modularui.screen.RichTooltip;
 import com.cleanroommc.modularui.screen.viewport.ModularGuiContext;
@@ -156,7 +158,15 @@ public class FluidSlot extends Widget<FluidSlot> implements Interactable, JeiGho
             this.textRenderer.setPos((int) (this.contentOffsetX + 0.5f), (int) (getArea().height - 5.5f));
             this.textRenderer.draw(s);
         }
-        if (isHovering()) {
+    }
+
+    @Override
+    public void drawOverlay(ModularGuiContext context, WidgetTheme widgetTheme) {
+        if (ModularUI.Mods.JEI.isLoaded() && (ModularUIJeiPlugin.draggingValidIngredient(this) || ModularUIJeiPlugin.hoveringOverIngredient(this))) {
+            GlStateManager.colorMask(true, true, true, false);
+            drawHighlight(getArea(), isHovering());
+            GlStateManager.colorMask(true, true, true, true);
+        } else if (isHovering()) {
             GlStateManager.colorMask(true, true, true, false);
             GuiDraw.drawRect(1, 1, getArea().w() - 2, getArea().h() - 2, getSlotHoverColor());
             GlStateManager.colorMask(true, true, true, true);

--- a/src/main/java/com/cleanroommc/modularui/widgets/slot/PhantomItemSlot.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/slot/PhantomItemSlot.java
@@ -33,7 +33,7 @@ public class PhantomItemSlot extends ItemSlot implements JeiGhostIngredientSlot<
 
     @Override
     protected void drawOverlay() {
-        if (ModularUI.Mods.JEI.isLoaded() && (ModularUIJeiPlugin.hasDraggingGhostIngredient() || ModularUIJeiPlugin.hoveringOverIngredient(this))) {
+        if (ModularUI.Mods.JEI.isLoaded() && (ModularUIJeiPlugin.draggingValidIngredient(this) || ModularUIJeiPlugin.hoveringOverIngredient(this))) {
             GlStateManager.colorMask(true, true, true, false);
             drawHighlight(getArea(), isHovering());
             GlStateManager.colorMask(true, true, true, true);

--- a/src/main/java/com/cleanroommc/modularui/widgets/slot/PhantomItemSlot.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/slot/PhantomItemSlot.java
@@ -8,8 +8,11 @@ import com.cleanroommc.modularui.utils.MouseData;
 import com.cleanroommc.modularui.value.sync.PhantomItemSlotSH;
 import com.cleanroommc.modularui.value.sync.SyncHandler;
 
+import mezz.jei.Internal;
+
 import net.minecraft.client.renderer.GlStateManager;
 
+import net.minecraft.enchantment.EnchantmentData;
 import net.minecraft.item.ItemStack;
 
 import org.jetbrains.annotations.NotNull;
@@ -73,10 +76,17 @@ public class PhantomItemSlot extends ItemSlot implements JeiGhostIngredientSlot<
 
     @Override
     public @Nullable ItemStack castGhostIngredientIfValid(@NotNull Object ingredient) {
-        return areAncestorsEnabled() &&
-                this.syncHandler.isPhantom() &&
-                ingredient instanceof ItemStack itemStack &&
-                this.syncHandler.isItemValid(itemStack) ? itemStack : null;
+        if (areAncestorsEnabled() && this.syncHandler.isPhantom()) {
+            if (ingredient instanceof EnchantmentData enchantmentData) {
+                ingredient = Internal.getIngredientRegistry().getIngredientHelper(enchantmentData).getCheatItemStack(enchantmentData);
+            }
+
+            if (ingredient instanceof ItemStack itemStack) {
+                return this.syncHandler.isItemValid(itemStack) ? itemStack : null;
+            }
+        }
+
+        return null;
     }
 
     @Override


### PR DESCRIPTION
- JEI dragging overlays not testing if the ingredient is valid during a drag. If you had a phantom Item and Fluid slot, both would highlight during the drag because the `hasDraggingGhostIngredient()` method doesn't consider if the ingredient being dragged is valid for the slot.
- FluidSlots not having any JEI dragging overlay.
- Fixes enchanted books not working with phantom Item Slots.