### PR TITLE
Allow LangKeys to work when MC is loading

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/drawable/text/LangKey.java
+++ b/src/main/java/com/cleanroommc/modularui/drawable/text/LangKey.java
@@ -15,7 +15,7 @@ public class LangKey extends BaseKey {
     private final Supplier<String> keySupplier;
     private final Supplier<Object[]> argsSupplier;
     private String string;
-    private long time = 0;
+    private long time = -1;
 
     public LangKey(@NotNull String key) {
         this(key, () -> null);


### PR DESCRIPTION
Fixes lang keys always returning `null` during the MC loading phase due to `ClientScreenHandler.getTicks()` returning `0` which early returns the cached string which is uninitialized by setting `time` to `-1`, so it can properly translate and cache the key.
Upstreaming GregTechCEu/GregTech#2854