### PR TITLE
add a tooltip override for TextFieldWidget to display custom tooltips 

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/test/TestTile.java
+++ b/src/main/java/com/cleanroommc/modularui/test/TestTile.java
@@ -269,6 +269,7 @@ public class TestTile extends TileEntity implements IGuiHolder<PosGuiData>, ITic
                                                                                 //.flex(flex -> flex.left(3)) // ?
                                                                                 .overlay(IKey.str("Button 2")))
                                                                         .child(new TextFieldWidget()
+                                                                                .addTooltipLine("this tooltip is overridden")
                                                                                 .size(60, 18)
                                                                                 .setTextAlignment(Alignment.Center)
                                                                                 .value(SyncHandlers.string(() -> this.value, val -> this.value = val))

--- a/src/main/java/com/cleanroommc/modularui/widgets/textfield/TextFieldWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/textfield/TextFieldWidget.java
@@ -1,8 +1,11 @@
 package com.cleanroommc.modularui.widgets.textfield;
 
 import com.cleanroommc.modularui.ModularUI;
+import com.cleanroommc.modularui.api.drawable.IDrawable;
 import com.cleanroommc.modularui.api.drawable.IKey;
+import com.cleanroommc.modularui.api.drawable.ITextLine;
 import com.cleanroommc.modularui.api.value.IStringValue;
+import com.cleanroommc.modularui.screen.RichTooltip;
 import com.cleanroommc.modularui.screen.viewport.ModularGuiContext;
 import com.cleanroommc.modularui.utils.MathUtils;
 import com.cleanroommc.modularui.utils.ParseResult;
@@ -13,6 +16,7 @@ import com.cleanroommc.modularui.value.sync.ValueSyncHandler;
 import org.jetbrains.annotations.NotNull;
 
 import java.text.ParsePosition;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Pattern;
@@ -27,6 +31,7 @@ public class TextFieldWidget extends BaseTextFieldWidget<TextFieldWidget> {
     private boolean numbers = false;
     private String mathFailMessage = null;
     private double defaultNumber = 0;
+    private boolean tooltipOverride = false;
 
     public double parse(String num) {
         ParseResult result = MathUtils.parseExpression(num, this.defaultNumber, true);
@@ -49,8 +54,10 @@ public class TextFieldWidget extends BaseTextFieldWidget<TextFieldWidget> {
             this.stringValue = new StringValue("");
         }
         setText(this.stringValue.getStringValue());
-        if (!hasTooltip()) {
+        if (!hasTooltip() && !tooltipOverride) {
             tooltipBuilder(tooltip -> tooltip.addLine(IKey.str(getText())));
+            // set back to false so this won't get triggered
+            tooltipOverride = false;
         }
     }
 
@@ -80,7 +87,7 @@ public class TextFieldWidget extends BaseTextFieldWidget<TextFieldWidget> {
 
     @Override
     public void drawForeground(ModularGuiContext context) {
-        if (hasTooltip() && getScrollData().isScrollBarActive(getScrollArea()) && isHoveringFor(getTooltip().getShowUpTimer())) {
+        if (hasTooltip() && (tooltipOverride || getScrollData().isScrollBarActive(getScrollArea())) && isHoveringFor(getTooltip().getShowUpTimer())) {
             getTooltip().draw(getContext());
         }
     }
@@ -207,5 +214,88 @@ public class TextFieldWidget extends BaseTextFieldWidget<TextFieldWidget> {
         this.stringValue = stringValue;
         setValue(stringValue);
         return this;
+    }
+
+    /**
+     *  Normally, Tooltips on text field widgets are used to display the contents of the widget when the scrollbar is active
+     *  This value is an override, that allows the methods provided by {@link com.cleanroommc.modularui.api.widget.ITooltip} to be used
+     *  Every method that adds a tooltip from ITooltip is overridden to enable the tooltipOverride
+     * @param value - sets the tooltip override on or off
+     */
+    public TextFieldWidget setTooltipOverride(boolean value) {
+        this.tooltipOverride = value;
+        return this;
+    }
+    @Override
+    public TextFieldWidget tooltipBuilder(Consumer<RichTooltip> tooltipBuilder) {
+        tooltipOverride = true;
+        return super.tooltipBuilder(tooltipBuilder);
+    }
+
+    @Override
+    public TextFieldWidget tooltip(RichTooltip tooltip) {
+        tooltipOverride = true;
+        return super.tooltip(tooltip);
+    }
+
+    @Override
+    public TextFieldWidget tooltip(Consumer<RichTooltip> tooltipConsumer) {
+        tooltipOverride = true;
+        return super.tooltip(tooltipConsumer);
+    }
+
+    @Override
+    public @NotNull RichTooltip tooltip() {
+        tooltipOverride = true;
+        return super.tooltip();
+    }
+
+    @Override
+    public TextFieldWidget tooltipDynamic(Consumer<RichTooltip> tooltipBuilder) {
+        tooltipOverride = true;
+        return super.tooltipDynamic(tooltipBuilder);
+    }
+
+    @Override
+    public TextFieldWidget addTooltipDrawableLines(Iterable<IDrawable> lines) {
+        tooltipOverride = true;
+        return super.addTooltipDrawableLines(lines);
+    }
+
+    @Override
+    public TextFieldWidget addTooltipElement(String s) {
+        tooltipOverride = true;
+        return super.addTooltipElement(s);
+    }
+
+    @Override
+    public TextFieldWidget addTooltipElement(IDrawable drawable) {
+        tooltipOverride = true;
+        return super.addTooltipElement(drawable);
+    }
+
+    @Override
+    public TextFieldWidget addTooltipLine(String line) {
+        tooltipOverride = true;
+        return super.addTooltipLine(line);
+    }
+
+    @Override
+    public TextFieldWidget addTooltipLine(ITextLine line) {
+        tooltipOverride = true;
+
+        return super.addTooltipLine(line);
+    }
+
+    @Override
+    public TextFieldWidget addTooltipLine(IDrawable drawable) {
+        tooltipOverride = true;
+        return super.addTooltipLine(drawable);
+    }
+
+    @Override
+    public TextFieldWidget addTooltipStringLines(Iterable<String> lines) {
+        tooltipOverride = true;
+        return super.addTooltipStringLines(lines);
     }
 }


### PR DESCRIPTION
This PR introduces a new field into TextFieldWidget called `tooltipOverride`

its a boolean that when true, will allow custom tooltips to display (and to always display) on the text field widget when hovered.

as it stands, the tooltip is reserved for displaying the text field widget's contents ONLY when the scrollbar is activated

**with override**
<img width="1062" height="558" alt="image" src="https://github.com/user-attachments/assets/4ea8ec8f-335c-45b9-b90f-4b3da9e8b05f" />

**without override**, only shows up in the same case as it used to
<img width="1058" height="400" alt="image" src="https://github.com/user-attachments/assets/bd3228f5-3941-4b94-8dad-0b3b3150c76c" />

