### PR TITLE
Fixes the Text Changed String check

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/widgets/TextWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/TextWidget.java
@@ -14,6 +14,7 @@ import net.minecraft.util.text.TextFormatting;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Objects;
 import java.util.function.IntSupplier;
 
 public class TextWidget<W extends TextWidget<W>> extends Widget<W> {
@@ -52,7 +53,7 @@ public class TextWidget<W extends TextWidget<W>> extends Widget<W> {
 
     protected String checkString() {
         String text = this.key.getFormatted();
-        if ((this.lastText == null && !text.isEmpty()) || this.lastText != null && !this.lastText.equals(text)) {
+        if (!Objects.equals(this.lastText, text)) {
             onTextChanged(text);
             this.lastText = text;
         }


### PR DESCRIPTION
Ports the Mixin from here: https://github.com/GregTechCEu/GregTech/pull/2868 Which solves an issue that we found during updating MUI2 where the text would not be properly updated if the widget did not have text originally.

I went with an empty check for the new text, because as far as I could see all the text returned by `this.key.getFormatted()` was non null.