### PR TITLE
Fix Animator Crash when Widget is Disabled

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/widgets/ScrollingTextWidget.java
+++ b/src/main/java/com/cleanroommc/modularui/widgets/ScrollingTextWidget.java
@@ -33,7 +33,7 @@ public class ScrollingTextWidget extends TextWidget<ScrollingTextWidget> {
     @Override
     public void dispose() {
         super.dispose();
-        if (this.isEnabled()) {
+        if (this.animator != null) {
             this.animator.stop(true);
         }
     }


### PR DESCRIPTION
Fixes a crash with the Scrolling Text Widget when no default animator is supplied, and the Widget is disabled. Because the widget is disabled, it does not have a chance to be assigned the default animator, so the animator will be null when the parent panel is closed and `dispose` is called.