### PR TITLE
Fix byte array and BigInteger ByteBufAdapters

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/utils/serialization/ByteBufAdapters.java
+++ b/src/main/java/com/cleanroommc/modularui/utils/serialization/ByteBufAdapters.java
@@ -32,7 +32,7 @@ public class ByteBufAdapters {
 
         @Override
         public void serialize(PacketBuffer buffer, byte[] u) throws IOException {
-            buffer.writeBytes(u);
+            buffer.writeByteArray(u);
         }
 
         @Override
@@ -81,7 +81,7 @@ public class ByteBufAdapters {
 
         @Override
         public void serialize(PacketBuffer buffer, BigInteger u) throws IOException {
-            buffer.writeBytes(u.toByteArray());
+            buffer.writeByteArray(u.toByteArray());
         }
 
         @Override


### PR DESCRIPTION
The `byte[]` and `BigInteger` `ByteBufAdapter`s were mistakenly written to use `ByteBuf#writeBytes` in https://github.com/CleanroomMC/ModularUI/commit/390e450db5d92ea3af503f0e7e0d2d126b0d4d26 instead of `PacketBuffer#writeByteArray` which would lead to numerous errors when they tried to deserialize a packet since there would be no varInt to get the length of the array.