### PR TITLE
Fix PanelSyncManger using the wrong method in `getOrCreateSyncHandler()`

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/value/sync/PanelSyncManager.java
+++ b/src/main/java/com/cleanroommc/modularui/value/sync/PanelSyncManager.java
@@ -373,7 +373,7 @@ public class PanelSyncManager {
     }
 
     public <T extends SyncHandler> T getOrCreateSyncHandler(String name, int id, Class<T> clazz, Supplier<T> supplier) {
-        SyncHandler syncHandler = getSyncHandler(name);
+        SyncHandler syncHandler = findSyncHandlerNullable(name, id);
         if (syncHandler == null) {
             if (isLocked() && !this.allowSyncHandlerRegistration) {
                 // registration is locked, and we don't have permission to temporarily bypass lock
@@ -387,7 +387,7 @@ public class PanelSyncManager {
             return t;
         }
         if (clazz.isAssignableFrom(syncHandler.getClass())) {
-            return (T) syncHandler;
+            return clazz.cast(syncHandler);
         }
         throw new IllegalStateException("SyncHandler for key " + makeSyncKey(name, id) + " is of type " + syncHandler.getClass() + ", but type " + clazz + " was expected!");
     }
@@ -434,11 +434,10 @@ public class PanelSyncManager {
         return findSyncHandler(name, 0);
     }
 
-    @SuppressWarnings("unchecked")
     public <T extends SyncHandler> @Nullable T findSyncHandlerNullable(String name, int id, Class<T> type) {
         SyncHandler syncHandler = this.syncHandlers.get(makeSyncKey(name, id));
         if (syncHandler != null && type.isAssignableFrom(syncHandler.getClass())) {
-            return (T) syncHandler;
+            return type.cast(syncHandler);
         }
         return null;
     }
@@ -447,7 +446,6 @@ public class PanelSyncManager {
         return findSyncHandlerNullable(name, 0, type);
     }
 
-    @SuppressWarnings("unchecked")
     public <T extends SyncHandler> @NotNull T findSyncHandler(String name, int id, Class<T> type) {
         SyncHandler syncHandler = this.syncHandlers.get(makeSyncKey(name, id));
         if (syncHandler == null) {
@@ -457,7 +455,7 @@ public class PanelSyncManager {
             throw new ClassCastException("Expected to find sync handler with key '" + makeSyncKey(name, id) + "' of type '" + type.getName()
                     + "', but found type '" + syncHandler.getClass().getName() + "'.");
         }
-        return (T) syncHandler;
+        return type.cast(syncHandler);
     }
 
     public <T extends SyncHandler> @NotNull T findSyncHandler(String name, Class<T> type) {


### PR DESCRIPTION
Previously, `getSyncHandler()` in `getOrCreateSyncHandler()` was called with just the name part of the map key, meaning it will never find the right sync handler and always create a new one. 

Otherwise if you do pass in the map key to `name` and it can't find the sync handler, you end up syncing the new sync handler with the int id attached twice, giving it the wrong map key.

also uses the class `cast()` method to remove those unchecked suppressions