### PR TITLE
Follow-up fix for temporary compat with AE2 GUIs

### DIFF
--- a/src/main/java/com/cleanroommc/modularui/core/ClassTransformer.java
+++ b/src/main/java/com/cleanroommc/modularui/core/ClassTransformer.java
@@ -15,22 +15,31 @@ public class ClassTransformer implements IClassTransformer {
 
     @Override
     public byte[] transform(String name, String transformedName, byte[] basicClass) {
-        if (!ModularUICore.stackUpLoaded) {
-            // Temporarily use AE2's implementation if it's loaded
-            if (ModularUICore.ae2Loaded && transformedName.equals(PacketByteBufferVisitor.PACKET_UTIL_CLASS)) {
+        // Don't patch over StackUp
+        if (ModularUICore.stackUpLoaded) {
+            return basicClass;
+        }
+        // Patch using AE2's implementation if it's loaded (temporary, see #155)
+        if (ModularUICore.ae2Loaded) {
+            // AE2 is missing PacketUtilPatch, patch it in
+            if (transformedName.equals(PacketByteBufferVisitor.PACKET_UTIL_CLASS)) {
                 Consumer<ClassNode> consumer = (node) -> {
                     ClassSplicer.spliceClasses(node, "com.cleanroommc.modularui.core.temp.PacketUtilPatch",
                             "writeItemStackFromClientToServer");
                 };
                 ModularUICore.LOGGER.info("Applied {} ASM, specific for AE2, from ModularUI", transformedName);
                 return ClassSplicer.processNode(basicClass, consumer);
-            } else if (transformedName.equals(PacketByteBufferVisitor.PACKET_UTIL_CLASS) ||
+            }
+            // Don't patch over AE2's PacketBufferPatch
+            return basicClass;
+        }
+        // Otherwise apply ModularUI's patches
+        if (transformedName.equals(PacketByteBufferVisitor.PACKET_UTIL_CLASS) ||
                     transformedName.equals(PacketByteBufferVisitor.PACKET_BUFFER_CLASS)) {
                 ClassWriter classWriter = new ClassWriter(0);
                 new ClassReader(basicClass).accept(new PacketByteBufferVisitor(classWriter), 0);
                 ModularUICore.LOGGER.info("Applied {} ASM from ModularUI", transformedName);
                 return classWriter.toByteArray();
-            }
         }
         return basicClass;
     }


### PR DESCRIPTION
Turns out I forgot to test the fix in #156 actually worked after making requested changes, and AE2 GUIs still crash on dedicated servers as a result. The `PacketBuffer` patch was supposed to be skipped if AE2 is loaded, which this PR fixes. I've tested it this time that oversized slots in an ME interface can actually have items taken from without disconnecting.